### PR TITLE
fix(backend-worker): use temp file to get nsjail log

### DIFF
--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/SubmitExecService.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/SubmitExecService.kt
@@ -50,33 +50,35 @@ class SubmitExecService(private val applicationConfig: ApplicationConfig) {
             )
 
         return withContext(Dispatchers.IO) {
-            val logFile = File(userDirectory, "nsjail.log")
-            logFile.deleteOnExit()
-            logFile.createNewFile()
-            val processBuilder =
-                ProcessBuilder(
-                    listOf(
-                        applicationConfig.nsjailPath,
-                        *applicationConfig.nsjailParameter.toTypedArray(),
-                        "--chroot",
-                        userDirectory.absolutePath,
-                        "--log",
-                        logFile.absolutePath,
-                        "--",
-                        "/program",
+            val logFile = File.createTempFile("nsjail", ".log", userDirectory)
+            try {
+                val processBuilder =
+                    ProcessBuilder(
+                        listOf(
+                            applicationConfig.nsjailPath,
+                            *applicationConfig.nsjailParameter.toTypedArray(),
+                            "--chroot",
+                            userDirectory.absolutePath,
+                            "--log",
+                            logFile.absolutePath,
+                            "--",
+                            "/program",
+                        )
                     )
+                processBuilder.redirectErrorStream(true)
+                val process = processBuilder.start()
+                val output = process.inputStream.bufferedReader().use { it.readText() }
+                val sandbox = logFile.readLines().joinToString("\n")
+                val exitCode = process.waitFor()
+                ExecPost200ResponseDataInnerDTO(
+                    userId = userId,
+                    output = output,
+                    sandbox = sandbox,
+                    if (exitCode == 0) null else ExecutionError(exitCode),
                 )
-            processBuilder.redirectErrorStream(true)
-            val process = processBuilder.start()
-            val output = process.inputStream.bufferedReader().use { it.readText() }
-            val sandbox = logFile.readLines().joinToString("\n")
-            val exitCode = process.waitFor()
-            ExecPost200ResponseDataInnerDTO(
-                userId = userId,
-                output = output,
-                sandbox = sandbox,
-                if (exitCode == 0) null else ExecutionError(exitCode),
-            )
+            } finally {
+                logFile.delete()
+            }
         }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced log management and error handling during task execution. Temporary log files are now automatically removed after use, ensuring smoother resource cleanup even when errors occur. These improvements contribute to a more reliable and stable process execution, ultimately enhancing the overall performance without affecting the visible user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->