### PR TITLE
chore(docker): update JWT secret handling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -196,6 +196,7 @@ jobs:
           build-args: |
             NSJAIL_REPO=${{ env.NSJAIL_REPO }}
             NSJAIL_BRANCH=${{ env.NSJAIL_REF }}
+            CACHE_BUSTER=${{ github.sha }}
 
       - name: Set Image Names with Determined Tag
         run: |

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -15,7 +15,6 @@ WORKDIR /app
 COPY backend-controller/target/snake-controller.jar controller.jar
 
 # Environment Variables specific or defaulted for Controller
-ENV JWT_SECRET=test-secret
 ENV WARN_AUDIT_FAILURE=true
 
 # Volume for external configuration
@@ -29,6 +28,5 @@ ENTRYPOINT ["/usr/bin/tini", "--", "sh", "-c", "echo \"Starting controller...\" 
     java -jar controller.jar \
     --server.port=8080 \
     --spring.config.additional-location=file:/app/config/application.yml \
-    --cheese-auth.jwt-secret=${JWT_SECRET} \
     --cheese-auth.warn-audit-failure=${WARN_AUDIT_FAILURE} \
     "]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # Builds nsjail in a builder stage based on the same final image base
 
 # --- Stage 1: Build Nsjail ---
-FROM openjdk:25-jdk-slim as nsjail_builder
+FROM openjdk:25-jdk-slim AS nsjail_builder
 
 ARG NSJAIL_REPO=https://github.com/SageSeekerSociety/nsjail.git
 ARG NSJAIL_BRANCH=master

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -6,6 +6,7 @@ FROM openjdk:25-jdk-slim AS nsjail_builder
 
 ARG NSJAIL_REPO=https://github.com/SageSeekerSociety/nsjail.git
 ARG NSJAIL_BRANCH=master
+ARG CACHE_BUSTER=build
 
 USER root
 
@@ -20,7 +21,8 @@ RUN apt-get update && \
 WORKDIR /usr/local/src
 
 # Clone or update nsjail source, echo CACHE_BUSTER to help invalidate layer
-RUN echo "Preparing nsjail source from ${NSJAIL_REPO} branch ${NSJAIL_BRANCH}..." && \
+RUN echo "Cache Buster: ${CACHE_BUSTER}" && \
+    echo "Preparing nsjail source from ${NSJAIL_REPO} branch ${NSJAIL_BRANCH}..." && \
     NSJAIL_SRC_DIR="nsjail" && \
     if [ -d "$NSJAIL_SRC_DIR/.git" ]; then \
     echo "Nsjail directory exists. Fetching and resetting to origin/${NSJAIL_BRANCH}..."; \

--- a/backend-controller/src/main/resources/application.yml
+++ b/backend-controller/src/main/resources/application.yml
@@ -27,7 +27,7 @@ server:
   port: 8080
 
 cheese-auth:
-  jwt-secret: test-secret
+  jwt-secret: ${JWT_SECRET:test-secret}
   warn-audit-failure: true
   auth-server-url: ${CHEESE_AUTH_SERVER_URL:http://localhost:8080}
 

--- a/backend-worker/src/main/resources/application.yml
+++ b/backend-worker/src/main/resources/application.yml
@@ -34,11 +34,6 @@ management:
     health:
       show-details: when_authorized # 或 always/never
 
-cheese-auth:
-  jwt-secret: test-secret
-  warn-audit-failure: true
-  auth-server-url: ${CHEESE_AUTH_SERVER_URL:http://localhost:8080}
-
 application:
   compiler-path: /bin/clang++
   compiler-parameter:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated configuration to allow the JWT secret to be set via environment variable, improving flexibility for deployment.
  - Removed unused authentication configuration from the worker service.
  - Made a minor change to Docker build instructions for consistency (capitalization of build stage alias).
  - Added a build argument to improve Docker image caching during worker builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->