### PR TITLE
fix: add requesting user field to `execution_job` schema

### DIFF
--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/ExecutionJob.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/ExecutionJob.kt
@@ -14,6 +14,10 @@ import org.rucca.snake.common.domain.model.JobStatus
             Index(name = "idx_execution_jobs_status", columnList = "status"),
             Index(name = "idx_execution_jobs_submit_time", columnList = "submitTime"),
             Index(name = "idx_execution_jobs_session_user", columnList = "sessionId, userId"),
+            Index(
+                name = "idx_execution_jobs_session_requesting_user",
+                columnList = "sessionId, requestingUserId",
+            ),
         ],
 )
 data class ExecutionJob(
@@ -35,4 +39,5 @@ data class ExecutionJob(
     @Column(length = 255) var clientRequestId: String? = null,
     @Lob @Column(columnDefinition = "TEXT") var errorDetails: String? = null,
     @Column(columnDefinition = "uuid") var sessionId: UUID? = null,
+    var requestingUserId: Long? = null, // User who requested the job, if different from owner
 )

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
@@ -11,15 +11,16 @@ interface ExecutionJobRepository : JpaRepository<ExecutionJob, UUID> {
     fun findByUserIdOrderBySubmitTimeDesc(userId: Long): List<ExecutionJob>
 
     /**
- * Retrieves all ExecutionJob entities with job IDs contained in the specified collection.
- *
- * @param jobIds A collection of job UUIDs to filter by.
- * @return A list of ExecutionJob entities matching the provided job IDs.
- */
-fun findAllByJobIdIn(jobIds: Collection<UUID>): List<ExecutionJob>
+     * Retrieves all ExecutionJob entities with job IDs contained in the specified collection.
+     *
+     * @param jobIds A collection of job UUIDs to filter by.
+     * @return A list of ExecutionJob entities matching the provided job IDs.
+     */
+    fun findAllByJobIdIn(jobIds: Collection<UUID>): List<ExecutionJob>
 
     /**
-     * Retrieves the job IDs of all execution jobs associated with the specified session and requesting user.
+     * Retrieves the job IDs of all execution jobs associated with the specified session and
+     * requesting user.
      *
      * @param sessionId The unique identifier of the session.
      * @param requestingUserId The ID of the user who requested the jobs.
@@ -34,9 +35,10 @@ fun findAllByJobIdIn(jobIds: Collection<UUID>): List<ExecutionJob>
     ): List<UUID>
 
     /**
- * Determines whether an `ExecutionJob` exists with the specified job ID and user ID.
- *
- * @return `true` if an `ExecutionJob` with the given job ID and user ID exists; otherwise, `false`.
- */
-fun existsByJobIdAndUserId(jobId: UUID, userId: Long): Boolean
+     * Determines whether an `ExecutionJob` exists with the specified job ID and user ID.
+     *
+     * @return `true` if an `ExecutionJob` with the given job ID and user ID exists; otherwise,
+     *   `false`.
+     */
+    fun existsByJobIdAndUserId(jobId: UUID, userId: Long): Boolean
 }

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
@@ -1,6 +1,6 @@
 package org.rucca.snake.common.infra.persistence.repository
 
-import java.util.UUID
+import java.util.*
 import org.rucca.snake.common.infra.persistence.entity.ExecutionJob
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
@@ -13,9 +13,12 @@ interface ExecutionJobRepository : JpaRepository<ExecutionJob, UUID> {
     fun findAllByJobIdIn(jobIds: Collection<UUID>): List<ExecutionJob>
 
     @Query(
-        "SELECT ej.jobId FROM ExecutionJob ej WHERE ej.sessionId = :sessionId AND ej.userId = :userId"
+        "SELECT ej.jobId FROM ExecutionJob ej WHERE ej.sessionId = :sessionId AND ej.requestingUserId = :requestingUserId"
     )
-    fun findJobIdsBySessionIdAndUserId(sessionId: UUID, userId: Long): List<UUID>
+    fun findJobIdsBySessionIdAndRequestingUserId(
+        sessionId: UUID,
+        requestingUserId: Long,
+    ): List<UUID>
 
     fun existsByJobIdAndUserId(jobId: UUID, userId: Long): Boolean
 }

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
@@ -10,8 +10,21 @@ import org.springframework.stereotype.Repository
 interface ExecutionJobRepository : JpaRepository<ExecutionJob, UUID> {
     fun findByUserIdOrderBySubmitTimeDesc(userId: Long): List<ExecutionJob>
 
-    fun findAllByJobIdIn(jobIds: Collection<UUID>): List<ExecutionJob>
+    /**
+ * Retrieves all ExecutionJob entities with job IDs contained in the specified collection.
+ *
+ * @param jobIds A collection of job UUIDs to filter by.
+ * @return A list of ExecutionJob entities matching the provided job IDs.
+ */
+fun findAllByJobIdIn(jobIds: Collection<UUID>): List<ExecutionJob>
 
+    /**
+     * Retrieves the job IDs of all execution jobs associated with the specified session and requesting user.
+     *
+     * @param sessionId The unique identifier of the session.
+     * @param requestingUserId The ID of the user who requested the jobs.
+     * @return A list of job IDs matching the given session and requesting user.
+     */
     @Query(
         "SELECT ej.jobId FROM ExecutionJob ej WHERE ej.sessionId = :sessionId AND ej.requestingUserId = :requestingUserId"
     )
@@ -20,5 +33,10 @@ interface ExecutionJobRepository : JpaRepository<ExecutionJob, UUID> {
         requestingUserId: Long,
     ): List<UUID>
 
-    fun existsByJobIdAndUserId(jobId: UUID, userId: Long): Boolean
+    /**
+ * Determines whether an `ExecutionJob` exists with the specified job ID and user ID.
+ *
+ * @return `true` if an `ExecutionJob` with the given job ID and user ID exists; otherwise, `false`.
+ */
+fun existsByJobIdAndUserId(jobId: UUID, userId: Long): Boolean
 }

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobFlowService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobFlowService.kt
@@ -31,8 +31,12 @@ class JobFlowService(
     private val flowTimeout = 5.minutes
 
     /**
-     * Creates or retrieves a SharedFlow for a given Job ID. This should be called when a job is
-     * submitted or an SSE connection requests it.
+     * Returns a SharedFlow for the specified job ID, creating it if it does not already exist.
+     *
+     * Ensures that only one flow exists per job. The flow replays all past events to new subscribers and is suitable for use with Server-Sent Events (SSE) clients.
+     *
+     * @param jobId The unique identifier of the job.
+     * @return A SharedFlow emitting job events for the given job ID.
      */
     fun getJobFlow(jobId: UUID): SharedFlow<JobSseEvent> {
         // Compute if absent to ensure only one flow per jobId
@@ -51,6 +55,13 @@ class JobFlowService(
         }
     }
 
+    /**
+     * Retrieves all job event flows associated with a given session and requesting user.
+     *
+     * @param sessionId The session identifier to query jobs for.
+     * @param requestingUserId The user requesting the job flows.
+     * @return A list of shared flows, each emitting events for a specific job in the session.
+     */
     fun getJobFlowsBySessionId(
         sessionId: UUID,
         requestingUserId: Long,

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobFlowService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobFlowService.kt
@@ -1,6 +1,6 @@
 package org.rucca.snake.controller.domain.service
 
-import java.util.UUID
+import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.time.Duration.Companion.minutes
 import kotlinx.coroutines.*
@@ -51,8 +51,11 @@ class JobFlowService(
         }
     }
 
-    fun getJobFlowsBySessionId(sessionId: UUID, userId: Long): List<SharedFlow<JobSseEvent>> {
-        return jobQueryService.getJobIdsBySessionId(sessionId, userId).map { jobId ->
+    fun getJobFlowsBySessionId(
+        sessionId: UUID,
+        requestingUserId: Long,
+    ): List<SharedFlow<JobSseEvent>> {
+        return jobQueryService.getJobIdsBySessionId(sessionId, requestingUserId).map { jobId ->
             getJobFlow(jobId)
         }
     }

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobFlowService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobFlowService.kt
@@ -33,7 +33,8 @@ class JobFlowService(
     /**
      * Returns a SharedFlow for the specified job ID, creating it if it does not already exist.
      *
-     * Ensures that only one flow exists per job. The flow replays all past events to new subscribers and is suitable for use with Server-Sent Events (SSE) clients.
+     * Ensures that only one flow exists per job. The flow replays all past events to new
+     * subscribers and is suitable for use with Server-Sent Events (SSE) clients.
      *
      * @param jobId The unique identifier of the job.
      * @return A SharedFlow emitting job events for the given job ID.

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobQueryService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobQueryService.kt
@@ -19,6 +19,13 @@ class JobQueryService(
 ) {
     private val logger = LoggerFactory.getLogger(JobQueryService::class.java)
 
+    /**
+     * Retrieves a list of execution job IDs associated with the specified session and requesting user.
+     *
+     * @param sessionId The UUID of the session to query.
+     * @param requestingUserId The ID of the user requesting the job IDs.
+     * @return A list of job UUIDs for the given session and user, or an empty list if none are found.
+     */
     fun getJobIdsBySessionId(sessionId: UUID, requestingUserId: Long): List<UUID> {
         val jobIds =
             executionJobRepository.findJobIdsBySessionIdAndRequestingUserId(

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobQueryService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobQueryService.kt
@@ -20,11 +20,13 @@ class JobQueryService(
     private val logger = LoggerFactory.getLogger(JobQueryService::class.java)
 
     /**
-     * Retrieves a list of execution job IDs associated with the specified session and requesting user.
+     * Retrieves a list of execution job IDs associated with the specified session and requesting
+     * user.
      *
      * @param sessionId The UUID of the session to query.
      * @param requestingUserId The ID of the user requesting the job IDs.
-     * @return A list of job UUIDs for the given session and user, or an empty list if none are found.
+     * @return A list of job UUIDs for the given session and user, or an empty list if none are
+     *   found.
      */
     fun getJobIdsBySessionId(sessionId: UUID, requestingUserId: Long): List<UUID> {
         val jobIds =

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobQueryService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobQueryService.kt
@@ -1,6 +1,6 @@
 package org.rucca.snake.controller.domain.service
 
-import java.util.UUID
+import java.util.*
 import kotlinx.coroutines.*
 import org.rucca.snake.common.infra.persistence.repository.CompilationJobRepository
 import org.rucca.snake.common.infra.persistence.repository.ExecutionJobRepository
@@ -19,8 +19,12 @@ class JobQueryService(
 ) {
     private val logger = LoggerFactory.getLogger(JobQueryService::class.java)
 
-    fun getJobIdsBySessionId(sessionId: UUID, userId: Long): List<UUID> {
-        val jobIds = executionJobRepository.findJobIdsBySessionIdAndUserId(sessionId, userId)
+    fun getJobIdsBySessionId(sessionId: UUID, requestingUserId: Long): List<UUID> {
+        val jobIds =
+            executionJobRepository.findJobIdsBySessionIdAndRequestingUserId(
+                sessionId,
+                requestingUserId,
+            )
         if (jobIds.isEmpty()) {
             return emptyList()
         }

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
@@ -318,6 +318,7 @@ class JobSubmitService(
                 submitTime = submitTime,
                 clientRequestId = item.clientRequestId,
                 sessionId = sessionUuid,
+                requestingUserId = requestingUserId,
             )
 
         // 2. Save to Database

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
@@ -288,12 +288,16 @@ class JobSubmitService(
     }
 
     /**
-     * Internal transactional method to submit a single execution task. Separated to allow
-     * individual transaction management for batch items.
+     * Submits a single execution job, persisting it and sending the execution request to RabbitMQ within its own transaction.
      *
-     * @param item The single execution request item.
-     * @return The created ExecutionJob entity.
-     * @throws DataAccessException, AmqpException, RuntimeException on failure.
+     * @param item The execution request details.
+     * @param finalSessionId The session ID associated with the execution.
+     * @param requestingUserId The ID of the user initiating the request.
+     * @return The persisted ExecutionJob entity.
+     * @throws IllegalArgumentException If the session ID format is invalid.
+     * @throws DataAccessException If saving the job to the database fails.
+     * @throws AmqpException If sending the execution request to RabbitMQ fails.
+     * @throws RuntimeException For unexpected errors during database or messaging operations.
      */
     @Transactional // Each execution submission gets its own transaction
     internal suspend fun submitSingleExecutionInternal(

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
@@ -288,7 +288,8 @@ class JobSubmitService(
     }
 
     /**
-     * Submits a single execution job, persisting it and sending the execution request to RabbitMQ within its own transaction.
+     * Submits a single execution job, persisting it and sending the execution request to RabbitMQ
+     * within its own transaction.
      *
      * @param item The execution request details.
      * @param finalSessionId The session ID associated with the execution.

--- a/backend-controller/src/main/resources/db/migration/V4__execution_job_requesting_user_id.sql
+++ b/backend-controller/src/main/resources/db/migration/V4__execution_job_requesting_user_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE execution_jobs
+    ADD COLUMN requesting_user_id BIGINT;
+CREATE INDEX idx_execution_jobs_session_requesting_user ON execution_jobs (session_id, requesting_user_id);

--- a/backend-worker/src/main/resources/application.yml
+++ b/backend-worker/src/main/resources/application.yml
@@ -21,8 +21,8 @@ spring:
       ddl-auto: validate # 生产环境推荐使用 validate 或 none，通过 Flyway/Liquibase 管理 Schema
   data:
     redis:
-      host: localhost # Or your Redis host
-      port: 6379 # Or your Redis port
+      host: ${REDIS_HOST:localhost} # Or your Redis host
+      port: ${REDIS_PORT:6379} # Or your Redis port
       # password: your-password # Uncomment and set if your Redis has a password
       # timeout: 60000 # Connection timeout
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for tracking and querying jobs by the user who requested them, in addition to the job owner.
- **Chores**
  - Improved database indexing for faster queries involving session and requesting user.
  - Enhanced Redis configuration to support environment-based host and port settings for greater deployment flexibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->