### PR TITLE
perf(db): optimize job table for high-throughput writes

### DIFF
--- a/backend-common/pom.xml
+++ b/backend-common/pom.xml
@@ -16,8 +16,13 @@
     <description>Common classes and interfaces for the snake game backend</description>
     <!-- packaging 默认为 jar，无需显式指定 -->
 
-    <dependencies>
-        <!-- Kotlin 标准库 (父 POM 的 dependencyManagement 已管理版本) -->
+  <dependencies>
+    <!-- UUID v7 generator (JUG) -->
+    <dependency>
+      <groupId>com.fasterxml.uuid</groupId>
+      <artifactId>java-uuid-generator</artifactId>
+      <version>5.1.0</version>
+    </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/CompilationJob.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/CompilationJob.kt
@@ -3,6 +3,7 @@ package org.rucca.snake.common.infra.persistence.entity
 import jakarta.persistence.*
 import java.time.Instant
 import java.util.*
+import org.rucca.snake.common.utils.UuidV7
 import org.rucca.snake.common.domain.model.JobStatus
 
 @Entity
@@ -16,7 +17,7 @@ import org.rucca.snake.common.domain.model.JobStatus
         ],
 )
 data class CompilationJob(
-    @Id var jobId: UUID = UUID.randomUUID(),
+    @Id var jobId: UUID = UuidV7.generate(),
     @Column(nullable = false) var userId: Long = 0,
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/CompilationJob.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/CompilationJob.kt
@@ -14,6 +14,11 @@ import org.rucca.snake.common.domain.model.JobStatus
             Index(name = "idx_compilation_jobs_user_id", columnList = "userId"),
             Index(name = "idx_compilation_jobs_status", columnList = "status"),
             Index(name = "idx_compilation_jobs_submit_time", columnList = "submitTime"),
+            // Mirror Flyway V6 composite index (note: JPA cannot express DESC here)
+            Index(
+                name = "idx_compilation_jobs_user_submit_time",
+                columnList = "userId, submitTime",
+            ),
         ],
 )
 data class CompilationJob(

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/ExecutionJob.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/ExecutionJob.kt
@@ -3,6 +3,7 @@ package org.rucca.snake.common.infra.persistence.entity
 import jakarta.persistence.*
 import java.time.Instant
 import java.util.*
+import org.rucca.snake.common.utils.UuidV7
 import org.rucca.snake.common.domain.model.JobStatus
 
 @Entity
@@ -21,7 +22,7 @@ import org.rucca.snake.common.domain.model.JobStatus
         ],
 )
 data class ExecutionJob(
-    @Id var jobId: UUID = UUID.randomUUID(),
+    @Id var jobId: UUID = UuidV7.generate(),
     @Column(nullable = false) var userId: Long = 0,
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/ExecutionJob.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/entity/ExecutionJob.kt
@@ -16,8 +16,8 @@ import org.rucca.snake.common.domain.model.JobStatus
             Index(name = "idx_execution_jobs_submit_time", columnList = "submitTime"),
             Index(name = "idx_execution_jobs_session_user", columnList = "sessionId, userId"),
             Index(
-                name = "idx_execution_jobs_session_tick_requesting_user",
-                columnList = "sessionId, tickNumber, requestingUserId",
+                name = "idx_execution_jobs_session_requesting_user_tick",
+                columnList = "sessionId, requestingUserId, tickNumber",
             ),
         ],
 )

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/CompilationJobRepository.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/CompilationJobRepository.kt
@@ -1,8 +1,12 @@
 package org.rucca.snake.common.infra.persistence.repository
 
 import java.util.UUID
+import org.rucca.snake.common.domain.model.JobStatus
 import org.rucca.snake.common.infra.persistence.entity.CompilationJob
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -10,4 +14,34 @@ interface CompilationJobRepository : JpaRepository<CompilationJob, UUID> {
     fun findByUserIdOrderBySubmitTimeDesc(userId: Long): List<CompilationJob>
 
     fun existsByJobIdAndUserId(jobId: UUID, userId: Long): Boolean
+
+     /**
+      * Single-shot final update to avoid read-modify-write. Guarded by expected status.
+      */
+     @Modifying(clearAutomatically = true, flushAutomatically = true)
+     @Transactional
+     @Query(
+         """
+         UPDATE CompilationJob cj
+         SET cj.status = :status,
+             cj.startCompileTime = CASE WHEN cj.startCompileTime IS NULL THEN :startTime ELSE cj.startCompileTime END,
+             cj.endCompileTime = :endTime,
+             cj.compilerOutput = :compilerOutput,
+             cj.programStorageRef = :programStorageRef,
+             cj.errorDetails = :errorDetails,
+             cj.workerNodeId = :workerNodeId
+         WHERE cj.jobId = :jobId AND cj.status = :expectedStatus
+         """
+     )
+     fun updateFinalByIdIfStatus(
+         jobId: UUID,
+         expectedStatus: JobStatus,
+         status: JobStatus,
+         startTime: java.time.Instant?,
+         endTime: java.time.Instant?,
+         compilerOutput: String?,
+         programStorageRef: String?,
+         errorDetails: String?,
+         workerNodeId: String?,
+     ): Int
 }

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/infra/persistence/repository/ExecutionJobRepository.kt
@@ -2,8 +2,11 @@ package org.rucca.snake.common.infra.persistence.repository
 
 import java.util.*
 import org.rucca.snake.common.infra.persistence.entity.ExecutionJob
+import org.rucca.snake.common.domain.model.JobStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
+import org.springframework.transaction.annotation.Transactional
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -41,4 +44,41 @@ interface ExecutionJobRepository : JpaRepository<ExecutionJob, UUID> {
      *   `false`.
      */
     fun existsByJobIdAndUserId(jobId: UUID, userId: Long): Boolean
+
+    /**
+     * Single-shot final update to avoid read-modify-write. Uses a guard on expected current status
+     * (typically PENDING) for idempotency.
+     */
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Transactional
+    @Query(
+        """
+        UPDATE ExecutionJob ej
+        SET ej.status = :status,
+            ej.startExecutionTime = CASE WHEN ej.startExecutionTime IS NULL THEN :startTime ELSE ej.startExecutionTime END,
+            ej.endExecutionTime = :endTime,
+            ej.programOutput = :programOutput,
+            ej.cpuTimeSeconds = :cpuTimeSeconds,
+            ej.memoryKb = :memoryKb,
+            ej.exitCode = :exitCode,
+            ej.sandboxLogRef = :sandboxLogRef,
+            ej.errorDetails = :errorDetails,
+            ej.workerNodeId = :workerNodeId
+        WHERE ej.jobId = :jobId AND ej.status = :expectedStatus
+        """
+    )
+    fun updateFinalByIdIfStatus(
+        jobId: UUID,
+        expectedStatus: JobStatus,
+        status: JobStatus,
+        startTime: java.time.Instant?,
+        endTime: java.time.Instant?,
+        programOutput: String?,
+        cpuTimeSeconds: Double?,
+        memoryKb: Long?,
+        exitCode: Int?,
+        sandboxLogRef: String?,
+        errorDetails: String?,
+        workerNodeId: String?,
+    ): Int
 }

--- a/backend-common/src/main/kotlin/org/rucca/snake/common/utils/UuidV7.kt
+++ b/backend-common/src/main/kotlin/org/rucca/snake/common/utils/UuidV7.kt
@@ -1,0 +1,13 @@
+package org.rucca.snake.common.utils
+
+import com.fasterxml.uuid.Generators
+import java.util.UUID
+
+/**
+ * UUIDv7 generator.
+ */
+object UuidV7 {
+    fun generate(): UUID {
+        return Generators.timeBasedEpochGenerator().generate()
+    }
+}

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
@@ -9,6 +9,7 @@ import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.*
 import org.rucca.cheese.auth.AuthenticationService
 import org.rucca.cheese.auth.annotation.Guard
+import org.rucca.snake.common.utils.UuidV7
 import org.rucca.snake.controller.domain.model.ApiError
 import org.rucca.snake.controller.domain.model.ApiResponse
 import org.rucca.snake.controller.domain.service.JobFlowService
@@ -130,7 +131,7 @@ class CompileController(
                             try {
                                 val sseEvent =
                                     SseEmitter.event()
-                                        .id(UUID.randomUUID().toString())
+                                        .id(UuidV7.generate().toString())
                                         .name(event.eventType)
                                         .data(event, MediaType.APPLICATION_JSON)
                                 emitter.send(sseEvent)

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.filter
 import org.apache.catalina.connector.ClientAbortException
 import org.rucca.cheese.auth.AuthenticationService
 import org.rucca.cheese.auth.annotation.Guard
+import org.rucca.snake.common.utils.UuidV7
 import org.rucca.snake.controller.domain.model.ApiError
 import org.rucca.snake.controller.domain.model.ApiResponse
 import org.rucca.snake.controller.domain.model.BatchExecutionItem
@@ -90,7 +91,8 @@ class ExecuteController(
                     )
             }
 
-            val finalSessionId = firstSessionId ?: UUID.randomUUID().toString()
+            val finalSessionId =
+                firstSessionId ?: org.rucca.snake.common.utils.UuidV7.generate().toString()
             val finalRequests = requests.map { it.copy(sessionId = finalSessionId) }
 
             val results: Map<String, Result<String>> =
@@ -222,7 +224,7 @@ class ExecuteController(
                                         // 4. Construct and send the SSE event.
                                         val sseEvent =
                                             SseEmitter.event()
-                                                .id(UUID.randomUUID().toString())
+                                                .id(UuidV7.generate().toString())
                                                 .name(event.eventType)
                                                 .data(
                                                     event.copy(data = clientEventData),

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
@@ -24,6 +24,7 @@ import org.rucca.snake.common.infra.persistence.entity.CompilationJob
 import org.rucca.snake.common.infra.persistence.entity.ExecutionJob
 import org.rucca.snake.common.infra.persistence.repository.CompilationJobRepository
 import org.rucca.snake.common.infra.persistence.repository.ExecutionJobRepository
+import org.rucca.snake.common.utils.UuidV7
 import org.rucca.snake.common.utils.withSuspendingSpan
 import org.rucca.snake.controller.domain.model.BatchExecutionItem
 import org.rucca.snake.controller.domain.model.JobSseEvent
@@ -156,7 +157,7 @@ class JobSubmitService(
             logCurrentTrace("submitCompilation.entry")
             submissionCounter("compilation").increment()
 
-            val jobId = UUID.randomUUID()
+            val jobId = org.rucca.snake.common.utils.UuidV7.generate()
             val submitTime = Instant.now()
             val sourceCodeObjectKey = "sources/$userId/$jobId/source.cpp"
 
@@ -325,7 +326,7 @@ class JobSubmitService(
             val submittedJobIds = mutableListOf<UUID>()
 
             requests.forEachIndexed { index, item ->
-                val resultKey = item.clientRequestId ?: "batch_item_${index}_${UUID.randomUUID()}"
+                val resultKey = item.clientRequestId ?: "batch_item_${index}_${UuidV7.generate()}"
                 var submittedJobId: UUID? = null
                 try {
                     // Call a separate method for each item, which now correctly manages its own
@@ -401,7 +402,7 @@ class JobSubmitService(
         logCurrentTrace("submitSingleExecution.entry")
         submissionCounter("execution").increment()
 
-        val jobId = UUID.randomUUID()
+        val jobId = org.rucca.snake.common.utils.UuidV7.generate()
         val submitTime = Instant.now()
         val sessionUuid =
             runCatching { UUID.fromString(finalSessionId) }

--- a/backend-controller/src/main/resources/db/migration/V6__optimize_indexes.sql
+++ b/backend-controller/src/main/resources/db/migration/V6__optimize_indexes.sql
@@ -1,0 +1,19 @@
+-- Optimize indexes for common access patterns
+
+-- 1) For queries: findByUserIdOrderBySubmitTimeDesc(userId)
+-- Composite index supports filtering by user_id and sorting by submit_time without extra sort
+CREATE INDEX IF NOT EXISTS idx_compilation_jobs_user_submit_time
+    ON compilation_jobs (user_id, submit_time DESC);
+
+CREATE INDEX IF NOT EXISTS idx_execution_jobs_user_submit_time
+    ON execution_jobs (user_id, submit_time DESC);
+
+-- 2) For queries fetching job IDs by (session_id, requesting_user_id)
+-- Replace prior index ordering to better match equality predicates
+-- Old: (session_id, tick_number, requesting_user_id)
+-- New: (session_id, requesting_user_id, tick_number) and cover job_id for index-only scans
+DROP INDEX IF EXISTS idx_execution_jobs_session_tick_requesting_user;
+
+CREATE INDEX IF NOT EXISTS idx_execution_jobs_session_requesting_user_tick
+    ON execution_jobs (session_id, requesting_user_id, tick_number)
+    INCLUDE (job_id);

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/domain/service/CompileService.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/domain/service/CompileService.kt
@@ -63,11 +63,7 @@ class CompileService(
         val startTime = Instant.now()
 
         try {
-            // 1. Update DB Status to COMPILING
-            currentStatus = JobStatus.COMPILING
-            updateJobStatus(jobId, currentStatus, startTime = startTime)
-
-            // 2. Prepare compilation directory
+            // Prepare compilation directory (skip DB COMPILING state to reduce writes)
             val compileDir: Path =
                 withContext(Dispatchers.IO) {
                     try {
@@ -88,7 +84,7 @@ class CompileService(
                     }
                 }
 
-            // 3. Download Source Code from MinIO
+            // Download Source Code from MinIO
             logger.info(
                 "Downloading source code for job {} from MinIO key '{}' to '{}'",
                 jobId,
@@ -109,21 +105,13 @@ class CompileService(
                 )
                 currentStatus = JobStatus.ERROR
                 errorDetails = "Failed to download source code from storage."
-                // No need to proceed further if source isn't available
-                updateJobStatus(
-                    jobId,
-                    currentStatus,
-                    endTime = Instant.now(),
-                    errorDetails = errorDetails,
-                )
-                cleanupCompileDir(compileDir, jobId) // Clean up directory
-                // Re-throw to trigger NACK
+                // Re-throw to trigger NACK and let finally perform the single final DB update
                 throw RuntimeException("Failed to download source code for job $jobId")
             }
 
             logger.info("Successfully downloaded source code for job {}", jobId)
 
-            // 4. Execute Compilation
+            // Execute Compilation
             val compileResult = executeCompileCommand(sourceFilePath, outputFilePath)
             compileOutputText = compileResult.output // Store compiler output regardless of success
 
@@ -179,17 +167,18 @@ class CompileService(
             // Re-throw to ensure NACK
             throw e
         } finally {
-            // 6. Final DB Update (always attempt this)
+            // Final DB Update (single write including startTime)
             updateJobStatus(
                 jobId,
                 currentStatus,
+                startTime = startTime,
                 endTime = Instant.now(),
                 compilerOutput = compileOutputText,
                 programStorageRef = programStorageRef,
                 errorDetails = errorDetails,
             )
 
-            // 7. Notify Result via AMQP
+            // Notify Result via AMQP
             resultNotifier.notifyCompilationResult(
                 UUID.fromString(jobId),
                 request.userId,
@@ -197,7 +186,7 @@ class CompileService(
                 programStorageRef,
             )
 
-            // 8. Cleanup local compile directory
+            // Cleanup local compile directory
             cleanupCompileDir(userCompileDir, jobId)
         }
     }
@@ -285,8 +274,8 @@ class CompileService(
     }
 
     /**
-     * Helper function to update the job status in the database. Uses findById and save, which might
-     * not be atomic. Consider custom query for atomic updates if needed.
+     * Helper function to update the job status in the database. Use single-shot update to avoid
+     * read-modify-write and reduce DB load.
      */
     private suspend fun updateJobStatus(
         jobId: String,
@@ -297,46 +286,30 @@ class CompileService(
         programStorageRef: String? = null,
         errorDetails: String? = null,
     ) {
-        // Perform DB operations on the IO dispatcher, which is designed for blocking calls.
         withContext(Dispatchers.IO) {
             try {
-                // Find the job by its ID. orElse(null) is more idiomatic with Kotlin's null safety.
-                val job = compilationJobRepository.findById(UUID.fromString(jobId)).orElse(null)
-
-                if (job == null) {
-                    logger.error("Could not find job with ID {} to update status.", jobId)
-                    return@withContext // Exit if job is not found
+                val rows =
+                    compilationJobRepository.updateFinalByIdIfStatus(
+                        jobId = UUID.fromString(jobId),
+                        expectedStatus = JobStatus.PENDING,
+                        status = status,
+                        startTime = startTime,
+                        endTime = endTime,
+                        compilerOutput = compilerOutput,
+                        programStorageRef = programStorageRef,
+                        errorDetails = errorDetails,
+                        workerNodeId = applicationConfig.nodeId,
+                    )
+                if (rows == 0) {
+                    logger.warn(
+                        "No rows updated for compilation job {}. It may have been already finalized or not found.",
+                        jobId,
+                    )
+                } else {
+                    logger.info("Updated job {} status to {}", jobId, status)
                 }
-
-                // Use 'apply' for cleaner property updates on the entity object.
-                job.apply {
-                    this.status = status
-                    if (startTime != null && this.startCompileTime == null) {
-                        this.startCompileTime = startTime // Set start time only once
-                    }
-                    if (endTime != null) {
-                        this.endCompileTime = endTime
-                    }
-                    if (compilerOutput != null) {
-                        this.compilerOutput = compilerOutput // Update compiler output
-                    }
-                    if (programStorageRef != null) {
-                        this.programStorageRef = programStorageRef
-                    }
-                    if (errorDetails != null) {
-                        this.errorDetails = errorDetails
-                    }
-                    // Fetch worker ID if needed
-                    // this.workerNodeId = appConfig.workerId
-                }
-
-                // Save the updated job entity. This is a blocking call.
-                compilationJobRepository.save(job)
-                logger.info("Updated job {} status to {}", jobId, status)
             } catch (e: Exception) {
                 logger.error("Failed to update database for job {}: {}", jobId, e.message, e)
-                // This is problematic. If DB update fails, the job state might be inconsistent.
-                // Consider retry logic or marking the job as potentially inconsistent.
             }
         }
     }

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/domain/service/ExecuteService.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/domain/service/ExecuteService.kt
@@ -18,6 +18,8 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicInteger
 import java.util.regex.Pattern
 import kotlinx.coroutines.*
+import kotlin.random.Random
+import java.io.ByteArrayInputStream
 import kotlinx.coroutines.sync.Semaphore
 import kotlinx.coroutines.sync.withPermit
 import org.rucca.snake.common.domain.model.ExecutionRequest
@@ -32,6 +34,7 @@ import org.rucca.snake.worker.infra.amqp.ResultNotifier
 import org.rucca.snake.worker.infra.storage.MinioService
 import org.rucca.snake.worker.utils.deleteDirectoryRecursively
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Service
@@ -48,6 +51,8 @@ class ExecuteService(
     openTelemetry: OpenTelemetry,
     @Value("\${memory.ttl.minutes}") private val memoryTtlMinutes: Long,
     @Value("\${memory.max.size.kb}") private val memoryMaxSizeKb: Int,
+    @Qualifier("applicationCoroutineScope") private val appScope: CoroutineScope,
+    @Value("\${logging.upload.success-sample-rate:0.0}") private val successLogSampleRate: Double,
 ) {
     private val tracer: Tracer = openTelemetry.getTracer(ExecuteService::class.java.name)
 
@@ -129,6 +134,9 @@ class ExecuteService(
                 var sandboxLogContent: String? =
                     null // Store log content if needed for debugging or result
                 var errorDetails: String? = null
+                // Set when we decide to upload logs (failure or sampled success)
+                val logFileKey = "logs/$aiOwnerUserId/$jobId/nsjail.log"
+                var finalLogRef: String? = null
                 val startTime = Instant.now()
 
                 // Initialize previousMemoryData
@@ -206,13 +214,7 @@ class ExecuteService(
                     }
 
                 try {
-                    // 1. Update DB Status to RUNNING
-                    tracer.withSuspendingSpan("db.update_job_status") {
-                        updateJobStatus(jobId, JobStatus.RUNNING, startTime = startTime)
-                    }
-                    currentStatus = JobStatus.RUNNING
-
-                    // 2. Ensure execution directory exists
+                    // Ensure execution directory exists (skip DB RUNNING state to reduce writes)
                     withContext(Dispatchers.IO + Context.current().asContextElement()) {
                         try {
                             Files.createDirectories(executionDir)
@@ -267,7 +269,7 @@ class ExecuteService(
                         }
                     }
 
-                    // 4. Prepare Input File
+                    // Prepare Input File
                     withContext(Dispatchers.IO + Context.current().asContextElement()) {
                         try {
                             val aiInputContentBytes =
@@ -286,7 +288,7 @@ class ExecuteService(
                         }
                     }
 
-                    // 5. Execute in Sandbox (using Semaphore)
+                    // Execute in Sandbox (using Semaphore)
                     logger.debug("Job {} WAITING for nsjail permit...", jobId)
                     val startTimeNsjailWait = System.nanoTime()
 
@@ -319,7 +321,7 @@ class ExecuteService(
                         }
                     logger.info("Released nsjail permit for job {}", jobId)
 
-                    // 6. Process Nsjail Result
+                    // Process Nsjail Result
                     exitCode = nsjailResult.exitCode
                     // programOutput is now split into action and newMemoryData
                     // programOutput = nsjailResult.output // Old way
@@ -447,6 +449,11 @@ class ExecuteService(
                             memoryKb ?: "N/A",
                             errorDetails.take(200),
                         )
+                        // Failure: schedule async log upload and set ref
+                        if (Files.exists(logFile)) {
+                            finalLogRef = logFileKey
+                            scheduleAsyncLogUpload(logFileKey, logFile)
+                        }
                     } else {
                         logger.info(
                             "Execution job {} finished with status: {}. ExitCode: {}, CPU: {}s, Mem: {}KB.",
@@ -456,6 +463,11 @@ class ExecuteService(
                             cpuTimeSeconds ?: "N/A",
                             memoryKb ?: "N/A",
                         )
+                        // Optional sampling for successful logs
+                        if (shouldSampleSuccessLog() && Files.exists(logFile)) {
+                            finalLogRef = logFileKey
+                            scheduleAsyncLogUpload(logFileKey, logFile)
+                        }
                     }
                 } catch (e: TimeoutCancellationException) {
                     // This would typically be caught if the semaphore wait times out,
@@ -466,6 +478,11 @@ class ExecuteService(
                     )
                     currentStatus = JobStatus.ERROR // Or maybe a specific timeout status
                     errorDetails = "Worker operation timed out: ${e.message}"
+                    // On failure, schedule async log upload
+                    if (Files.exists(logFile)) {
+                        finalLogRef = logFileKey
+                        scheduleAsyncLogUpload(logFileKey, logFile)
+                    }
                     // Re-throw
                     throw e
                 } catch (e: Exception) {
@@ -477,39 +494,22 @@ class ExecuteService(
                     )
                     currentStatus = JobStatus.ERROR // Worker internal error
                     errorDetails = "Internal worker error during execution: ${e.message}"
+                    // On failure, schedule async log upload
+                    if (Files.exists(logFile)) {
+                        finalLogRef = logFileKey
+                        scheduleAsyncLogUpload(logFileKey, logFile)
+                    }
                     // Re-throw to ensure NACK
                     throw e
                 } finally {
                     jobOutcomeCounter(currentStatus).increment()
 
-                    val logFileKey = "logs/$aiOwnerUserId/$jobId/nsjail.log"
-                    var finalLogRef: String? = null
-                    if (Files.exists(logFile)) {
-                        try {
-                            tracer.withSuspendingSpan("minio.upload_log", ctx = Dispatchers.IO) {
-                                minioService
-                                    .uploadFile(
-                                        objectKey = logFileKey,
-                                        filePath = logFile,
-                                        contentType = "text/plain",
-                                    )
-                                    ?.also { finalLogRef = logFileKey }
-                            }
-                            logger.info("Uploaded nsjail log file for job {} to MinIO", jobId)
-                        } catch (e: Exception) {
-                            logger.error(
-                                "Failed to upload nsjail log file for job {}: {}",
-                                jobId,
-                                e.message,
-                            )
-                        }
-                    }
-
-                    // 7. Final DB Update
+                    // Final DB Update
                     tracer.withSuspendingSpan("db.update_job", ctx = Dispatchers.IO) {
                         updateJobStatus(
                             jobId = jobId,
                             status = currentStatus,
+                            startTime = startTime,
                             endTime = Instant.now(),
                             programOutput = action,
                             cpuTimeSeconds = cpuTimeSeconds,
@@ -547,7 +547,7 @@ class ExecuteService(
                         )
                     }
 
-                    // 8. Cleanup execution-specific directory (input, log)
+                    // Cleanup execution-specific directory (input, log)
                     tracer.withSuspendingSpan("fs.cleanup", ctx = Dispatchers.IO + NonCancellable) {
                         try {
                             if (Files.exists(executionDir)) {
@@ -567,6 +567,35 @@ class ExecuteService(
                         }
                     }
                 }
+            }
+        }
+    }
+
+    private fun shouldSampleSuccessLog(): Boolean {
+        if (successLogSampleRate <= 0.0) return false
+        if (successLogSampleRate >= 1.0) return true
+        return Random.nextDouble() < successLogSampleRate
+    }
+
+    private fun scheduleAsyncLogUpload(objectKey: String, filePath: Path) {
+        // Read the file eagerly to avoid races with cleanup
+        val data = runCatching { Files.readAllBytes(filePath) }.getOrElse {
+            logger.error("Read log file failed before async upload {}: {}", objectKey, it.message)
+            return
+        }
+        appScope.launch(Dispatchers.IO + Context.current().asContextElement()) {
+            try {
+                tracer.withSuspendingSpan("minio.upload_log.async") {
+                    minioService.uploadStream(
+                        objectKey = objectKey,
+                        inputStream = ByteArrayInputStream(data),
+                        size = data.size.toLong(),
+                        contentType = "text/plain",
+                    )
+                }
+                logger.info("Async uploaded nsjail log to MinIO: {}", objectKey)
+            } catch (e: Exception) {
+                logger.error("Async log upload failed for {}: {}", objectKey, e.message)
             }
         }
     }
@@ -876,27 +905,29 @@ class ExecuteService(
     ) {
         withContext(Dispatchers.IO) {
             try {
-                val job = executionJobRepository.findById(UUID.fromString(jobId)).orElse(null)
-
-                if (job == null) {
-                    logger.error("Execution job with ID {} not found for status update.", jobId)
-                    return@withContext // Exit if job not found
+                val rows =
+                    executionJobRepository.updateFinalByIdIfStatus(
+                        jobId = UUID.fromString(jobId),
+                        expectedStatus = JobStatus.PENDING,
+                        status = status,
+                        startTime = startTime,
+                        endTime = endTime,
+                        programOutput = programOutput,
+                        cpuTimeSeconds = cpuTimeSeconds,
+                        memoryKb = memoryKb,
+                        exitCode = exitCode,
+                        sandboxLogRef = sandboxLogRef,
+                        errorDetails = errorDetails,
+                        workerNodeId = applicationConfig.nodeId,
+                    )
+                if (rows == 0) {
+                    logger.warn(
+                        "No rows updated for execution job {}. It may have been already finalized or not found.",
+                        jobId,
+                    )
+                } else {
+                    logger.info("Updated execution job {} status to {}", jobId, status)
                 }
-
-                job.status = status
-                if (startTime != null && job.startExecutionTime == null)
-                    job.startExecutionTime = startTime
-                if (endTime != null) job.endExecutionTime = endTime
-                if (programOutput != null)
-                    job.programOutput = programOutput // TODO: Add OLE check/truncation?
-                job.cpuTimeSeconds = cpuTimeSeconds
-                job.memoryKb = memoryKb
-                job.exitCode = exitCode
-                job.sandboxLogRef = sandboxLogRef
-                job.errorDetails = errorDetails
-                //                job.workerNodeId = appConfig.workerId
-                executionJobRepository.save(job)
-                logger.info("Updated execution job {} status to {}", jobId, status)
             } catch (e: Exception) {
                 logger.error(
                     "Failed to update database for execution job {}: {}",


### PR DESCRIPTION
This PR introduces several critical database optimizations to resolve write contention and performance bottlenecks in the `execution_jobs` table under high load.

### Key Changes:

1.  **Primary Key Strategy:**
    - Replaced random `UUIDv4` with **`UUIDv7`** for the `jobId` primary key. This provides a time-ordered, k-sortable ID, transforming expensive random index writes into efficient sequential appends in PostgreSQL.

2.  **Reduced Write Amplification:**
    - The intermediate `RUNNING` status update has been removed from the worker's job lifecycle. Jobs are now updated only once upon completion, cutting the write operations on this hot table by 33%.

3.  **I/O Optimization:**
    - Sandbox log uploads to MinIO are now conditional and will **only occur on job failure**, significantly reducing unnecessary network and disk I/O for successful runs.

These changes are designed to substantially increase database throughput, reduce transaction latency, and improve the overall scalability of the job processing pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Time-ordered IDs (UUIDv7) for jobs, sessions, and SSE events improve ordering and traceability.
- Refactor
  - Consolidated job finalization into single atomic updates for greater reliability.
  - Asynchronous log uploads with optional sampling reduce latency and storage usage.
  - Improved execution preparation and error handling for more robust runs.
  - Added composite database indexes to speed up job lists and session lookups.
- Chores
  - Added UUID generation library dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->