### PR TITLE
feat(worker,controller): track execute timing across pub→delivered→start→done with metrics and headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `backend-common`: Shared entities, DTOs, utils, and constants.
+- `backend-controller`: Spring Boot API, Flyway migrations at `src/main/resources/db/migration`, OpenAPI spec at `openapi.yml`.
+- `backend-worker`: Async task processing (AMQP, MinIO, caching).
+- `docker-compose-deploy`: Local/production compose files, Grafana/Prometheus/Loki configs.
+- Tests live in `src/test/kotlin` per module. Kotlin sources in `src/main/kotlin`.
+
+## Build, Test, and Development Commands
+- `./mvnw clean verify`: Build all modules, run tests, generate reports.
+- `./mvnw -pl backend-controller spring-boot:run`: Run controller locally.
+- `./mvnw -pl backend-worker spring-boot:run`: Run worker locally.
+- `./mvnw -pl backend-controller -am generate-sources`: Regenerate API from `openapi.yml`.
+- `./mvnw spotless:apply`: Format Kotlin/Java/POM/Markdown.
+- `./rebuild.sh`: Package JARs and build local Docker images via compose.
+
+## Coding Style & Naming Conventions
+- Kotlin with ktfmt (KOTLINLANG) via Spotless; 4-space indentation, no tabs.
+- Packages follow `org.rucca.snake.*`.
+- Classes/records: PascalCase; methods/fields: camelCase; constants: UPPER_SNAKE_CASE.
+- OpenAPI-generated models end with `DTO` (see `backend-controller/.../model`). Do not edit generated files; update `openapi.yml` and regenerate.
+
+## Testing Guidelines
+- Frameworks: JUnit 5 + `kotlin-test` (module tests under `src/test/kotlin`).
+- Run tests: `./mvnw test` (module-scoped: `-pl <module>`).
+- Coverage: JaCoCo reports at `<module>/target/site/jacoco/index.html`. Keep meaningful coverage for business logic; add tests for new endpoints/services.
+- Test naming: mirror package structure; use descriptive method names (e.g., `shouldReturn404WhenPlayerMissing`).
+
+## Commit & Pull Request Guidelines
+- Use Conventional Commits: `feat:`, `fix:`, `perf:`, `refactor:`, `chore:`, optional scope e.g., `fix(worker): ...`. Reference issues with `(#123)` when applicable.
+- PRs must include: clear description, linked issue, test evidence (logs or coverage), and if API changes, the updated `openapi.yml` and regeneration notes.
+- Screenshots/log snippets welcome for observability changes (metrics/traces/logs).
+
+## Security & Configuration Tips
+- Never commit secrets. For Docker deploy, set `.env` in `docker-compose-deploy` (e.g., `JWT_SECRET`, `DB_PASSWORD`, `EMAIL_*`).
+- Validate Flyway migrations and roll-forward only; keep schema changes in `backend-controller` migrations.
+

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/service/JobSubmitService.kt
@@ -455,6 +455,7 @@ class JobSubmitService(
         finalSessionId: String,
         requestingUserId: Long,
     ) {
+        val publishTs = java.time.Instant.now()
         val request =
             ExecutionRequest(
                 jobId = savedJob.jobId.toString(),
@@ -464,12 +465,11 @@ class JobSubmitService(
                 memoryLimitKb = item.memoryLimitKb,
                 wallTimeLimitSeconds = item.wallTimeLimitSeconds,
                 clientRequestId = item.clientRequestId,
-                timestamp = savedJob.submitTime,
+                timestamp = publishTs,
                 sessionId = finalSessionId,
                 tickNumber = item.tickNumber,
                 requestingUserId = requestingUserId,
             )
-
         sendWithTracing(
             operation = "execute",
             exchange = requestsExchangeName,
@@ -481,6 +481,8 @@ class JobSubmitService(
             message.messageProperties.headers[AmqpConstants.HEADER_MESSAGE_TYPE] =
                 AmqpConstants.MESSAGE_TYPE_EXECUTE
             item.clientRequestId?.let { message.messageProperties.headers["clientRequestId"] = it }
+            // Add publish timestamp header (ISO-8601)
+            message.messageProperties.headers["execute.pub_ts"] = publishTs.toString()
             message
         }
     }

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/config/AmqpConfig.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/config/AmqpConfig.kt
@@ -226,7 +226,7 @@ class AmqpConfig {
     @Bean("autoAckRabbitListenerContainerFactory")
     fun autoAckRabbitListenerContainerFactory(
         connectionFactory: ConnectionFactory,
-        jsonMessageConverter: MessageConverter
+        jsonMessageConverter: MessageConverter,
     ): RabbitListenerContainerFactory<SimpleMessageListenerContainer> {
         val f = SimpleRabbitListenerContainerFactory()
         f.setConnectionFactory(connectionFactory)

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/domain/service/ExecuteService.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/domain/service/ExecuteService.kt
@@ -12,7 +12,10 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import jakarta.annotation.PostConstruct
 import jakarta.annotation.PreDestroy
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
 import java.io.IOException
+import java.io.InputStream
 import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -20,6 +23,7 @@ import java.time.Duration
 import java.time.Instant
 import java.util.*
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import java.util.regex.Pattern
 import kotlin.random.Random
 import kotlinx.coroutines.*
@@ -43,10 +47,6 @@ import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.stereotype.Service
 import org.springframework.transaction.support.TransactionTemplate
-import java.io.ByteArrayInputStream
-import java.io.ByteArrayOutputStream
-import java.io.InputStream
-import java.util.concurrent.atomic.AtomicLong
 
 @Service
 class ExecuteService(
@@ -81,50 +81,47 @@ class ExecuteService(
     private val enqueueDroppedCounter: Counter =
         meterRegistry.counter("db_enqueue.results.total", "status", "dropped")
 
-    private val batchProcessTimer: Timer =
-        meterRegistry.timer("db_process.batch.duration")
+    private val batchProcessTimer: Timer = meterRegistry.timer("db_process.batch.duration")
 
     private val batchProcessSizeSummary: DistributionSummary =
         meterRegistry.summary("db_process.batch.size")
 
     // Buffered channel to decouple DB/MQ from the critical path
-    private val resultChannel = Channel<ExecutionResultNotification>(capacity = RESULT_CHANNEL_CAPACITY)
+    private val resultChannel =
+        Channel<ExecutionResultNotification>(capacity = RESULT_CHANNEL_CAPACITY)
 
     private var resultProcessors: List<Job> = emptyList()
 
     @OptIn(DelicateCoroutinesApi::class)
     @PostConstruct
     private fun startResultProcessors() {
-        meterRegistry.gauge(
-            "nsjail.permits.available",
-            nsjailSemaphore,
-        ) { it.availablePermits.toDouble() }
+        meterRegistry.gauge("nsjail.permits.available", nsjailSemaphore) {
+            it.availablePermits.toDouble()
+        }
 
-        meterRegistry.gauge(
-            "db_enqueue.channel.occupancy.ratio",
-            channelOccupancy
-        ) { it.get().toDouble() / RESULT_CHANNEL_CAPACITY }
+        meterRegistry.gauge("db_enqueue.channel.occupancy.ratio", channelOccupancy) {
+            it.get().toDouble() / RESULT_CHANNEL_CAPACITY
+        }
 
         val workers = 8
-        resultProcessors = (0 until workers).map { idx ->
-            appScope.launch(Dispatchers.IO + Context.current().asContextElement()) {
-                val ch: ReceiveChannel<ExecutionResultNotification> = resultChannel
-                logger.info("Result processor-{} started", idx)
-                while (isActive && !ch.isClosedForReceive) {
-                    try {
-                        val batch = consumeBatch(ch, maxSize = 50, maxWaitMillis = 100)
-                        if (batch.isEmpty()) continue
-                        batchProcessSizeSummary.record(batch.size.toDouble())
-                        batchProcessTimer.recordSuspendable {
-                            processBatch(batch)
+        resultProcessors =
+            (0 until workers).map { idx ->
+                appScope.launch(Dispatchers.IO + Context.current().asContextElement()) {
+                    val ch: ReceiveChannel<ExecutionResultNotification> = resultChannel
+                    logger.info("Result processor-{} started", idx)
+                    while (isActive && !ch.isClosedForReceive) {
+                        try {
+                            val batch = consumeBatch(ch, maxSize = 50, maxWaitMillis = 100)
+                            if (batch.isEmpty()) continue
+                            batchProcessSizeSummary.record(batch.size.toDouble())
+                            batchProcessTimer.recordSuspendable { processBatch(batch) }
+                            logger.info("Processed DB update batch size={}", batch.size)
+                        } catch (e: Exception) {
+                            logger.error("Error in result processing batch", e)
                         }
-                        logger.info("Processed DB update batch size={}", batch.size)
-                    } catch (e: Exception) {
-                        logger.error("Error in result processing batch", e)
                     }
                 }
             }
-        }
         logger.info("Started {} background result processors", workers)
     }
 
@@ -155,7 +152,8 @@ class ExecuteService(
         transactionTemplate.executeWithoutResult {
             if (batch.isEmpty()) return@executeWithoutResult
 
-            val sql = """
+            val sql =
+                """
             UPDATE snake.execution_jobs
             SET status = ?,
                 end_execution_time = (?::timestamp),
@@ -168,45 +166,53 @@ class ExecuteService(
                 error_details = ?,
                 worker_node_id = ?
             WHERE job_id = (?::uuid) AND status = 'PENDING'
-            """.trimIndent()
+            """
+                    .trimIndent()
 
-            val batchArgs: List<Array<Any?>> = batch.map { r ->
-                arrayOf(
-                    r.status.name,
-                    r.endTime.let { java.sql.Timestamp.from(it) },
-                    r.action,
-                    r.programStderr,
-                    r.cpuTimeSeconds,
-                    r.memoryKb,
-                    r.exitCode,
-                    r.sandboxLogRef,
-                    r.errorDetails,
-                    r.workerNodeId,
-                    UUID.fromString(r.jobId)
-                )
-            }
-
-            val updateCounts = try {
-                jdbcTemplate.batchUpdate(sql, batchArgs)
-            } catch (ex: org.springframework.dao.DataAccessException) {
-                val cause = ex.cause
-                if (cause is org.postgresql.util.PSQLException) {
-                    logger.error("SQLState={}, Message={}, Detail={}, Where={}",
-                        cause.sqlState,
-                        cause.serverErrorMessage?.message,
-                        cause.serverErrorMessage?.detail,
-                        cause.serverErrorMessage?.where
+            val batchArgs: List<Array<Any?>> =
+                batch.map { r ->
+                    arrayOf(
+                        r.status.name,
+                        r.endTime.let { java.sql.Timestamp.from(it) },
+                        r.action,
+                        r.programStderr,
+                        r.cpuTimeSeconds,
+                        r.memoryKb,
+                        r.exitCode,
+                        r.sandboxLogRef,
+                        r.errorDetails,
+                        r.workerNodeId,
+                        UUID.fromString(r.jobId),
                     )
                 }
-                throw ex
-            }
+
+            val updateCounts =
+                try {
+                    jdbcTemplate.batchUpdate(sql, batchArgs)
+                } catch (ex: org.springframework.dao.DataAccessException) {
+                    val cause = ex.cause
+                    if (cause is org.postgresql.util.PSQLException) {
+                        logger.error(
+                            "SQLState={}, Message={}, Detail={}, Where={}",
+                            cause.sqlState,
+                            cause.serverErrorMessage?.message,
+                            cause.serverErrorMessage?.detail,
+                            cause.serverErrorMessage?.where,
+                        )
+                    }
+                    throw ex
+                }
 
             updateCounts.forEachIndexed { index, count ->
                 val result = batch[index]
                 if (count > 0) {
-//                    logger.info("Batch-updated job {} successfully to status {}", result.jobId, result.status)
+                    //                    logger.info("Batch-updated job {} successfully to status
+                    // {}", result.jobId, result.status)
                 } else {
-                    logger.info("Skipped batch-updating job {} (status was not PENDING). This is likely a duplicate.", result.jobId)
+                    logger.info(
+                        "Skipped batch-updating job {} (status was not PENDING). This is likely a duplicate.",
+                        result.jobId,
+                    )
                 }
             }
         }
@@ -226,6 +232,40 @@ class ExecuteService(
             .tag("type", "execute")
             .description("Measures the duration of execution job processing")
             .publishPercentiles(0.5, 0.95, 0.99) // 发布 P50, P95, P99 延迟
+            .publishPercentileHistogram(true)
+            .register(meterRegistry)
+
+    // Latency breakdown timers (registered once)
+    private val publishToDeliveredTimer: Timer =
+        Timer.builder("job.execute.latency.publish_to_delivered")
+            .tag("type", "execute")
+            .description("Time from publish (controller) to delivery (worker listener)")
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .publishPercentileHistogram(true)
+            .register(meterRegistry)
+
+    private val deliveredToStartTimer: Timer =
+        Timer.builder("job.execute.latency.delivered_to_start")
+            .tag("type", "execute")
+            .description("Time from delivery to sandbox start (after permit)")
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .publishPercentileHistogram(true)
+            .register(meterRegistry)
+
+    private val startToDoneTimer: Timer =
+        Timer.builder("job.execute.latency.start_to_done")
+            .tag("type", "execute")
+            .description("Time from sandbox start to sandbox done")
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .publishPercentileHistogram(true)
+            .register(meterRegistry)
+
+    private val publishToDoneTimer: Timer =
+        Timer.builder("job.execute.latency.publish_to_done")
+            .tag("type", "execute")
+            .description("End-to-end time from publish to sandbox done")
+            .publishPercentiles(0.5, 0.95, 0.99)
+            .publishPercentileHistogram(true)
             .register(meterRegistry)
 
     // Regex to parse the custom Cgroup Stats log line
@@ -244,7 +284,11 @@ class ExecuteService(
      * @param request The execution request data.
      * @param jobId The unique job ID.
      */
-    suspend fun processExecutionRequest(request: ExecutionRequest, jobId: String) {
+    suspend fun processExecutionRequest(
+        request: ExecutionRequest,
+        jobId: String,
+        deliveredTs: Instant,
+    ) {
         tracer.withSuspendingSpan("job.execute.process") {
             // Retrieve new fields from request
             val sessionId = request.sessionId
@@ -277,6 +321,15 @@ class ExecuteService(
             val programFileName = "program"
             val programPathInExecDir = executionDir.resolve(programFileName)
             val minioObjectKey = "programs/$aiOwnerUserId/$programFileName" // Key in MinIO
+
+            // Record publish -> delivered immediately
+            runCatching {
+                val p2d = Duration.between(request.timestamp, deliveredTs)
+                if (!p2d.isNegative && !p2d.isZero) publishToDeliveredTimer.record(p2d)
+            }
+
+            var sandboxStartTs: Instant? = null
+            var sandboxDoneTs: Instant? = null
 
             executionTimer.recordSuspendable {
                 var currentStatus = JobStatus.RECEIVED
@@ -441,6 +494,11 @@ class ExecuteService(
                     val waitTimeMs = (System.nanoTime() - startTimeNsjailWait) / 1_000_000.0
                     logger.info("Acquired nsjail permit for job {} in {} ms", jobId, waitTimeMs)
                     Span.current().setAttribute("nsjail.wait_ms", waitTimeMs)
+                    // start_ts: after acquiring permit, before starting sandbox
+                    sandboxStartTs = Instant.now()
+                    runCatching {
+                        deliveredToStartTimer.record(Duration.between(deliveredTs, sandboxStartTs))
+                    }
                     val nsjailResult: NsjailResult =
                         try {
                             tracer.withSuspendingSpan("nsjail.execute") {
@@ -469,6 +527,16 @@ class ExecuteService(
                             nsjailSemaphore.release()
                             logger.info("Released nsjail permit for job {}", jobId)
                         }
+                    // done_ts: right after execution returns
+                    sandboxDoneTs = Instant.now()
+                    runCatching {
+                        sandboxStartTs?.let { st ->
+                            val s2d = Duration.between(st, sandboxDoneTs)
+                            if (!s2d.isNegative && !s2d.isZero) startToDoneTimer.record(s2d)
+                        }
+                        val p2done = Duration.between(request.timestamp, sandboxDoneTs)
+                        if (!p2done.isNegative && !p2done.isZero) publishToDoneTimer.record(p2done)
+                    }
 
                     // Process Nsjail Result
                     exitCode = nsjailResult.exitCode
@@ -685,40 +753,84 @@ class ExecuteService(
                 } finally {
                     jobOutcomeCounter(currentStatus).increment()
 
-                    resultNotification = ExecutionResultNotification(
-                        jobId = jobId,
-                        userId = aiOwnerUserId,
-                        status = currentStatus,
-                        sessionId = sessionId,
-                        tickNumber = tickNumber,
-                        cpuTimeSeconds = cpuTimeSeconds,
-                        memoryKb = memoryKb,
-                        exitCode = exitCode,
-                        action = action.takeIf { it.isNotBlank() },
-                        programStderr = programStderr,
-                        newMemoryData =
-                            if (currentStatus == JobStatus.SUCCESS) memoryDataForRedis
-                            else null,
-                        errorDetails = errorDetails.takeUnless { it.isNullOrBlank() },
-                        sandboxLogRef = finalLogRef,
-                        clientRequestId = request.clientRequestId,
-                        workerNodeId = applicationConfig.nodeId,
-                        submitTime = request.timestamp,
-                        startTime = startTime,
-                        endTime = Instant.now(),
-                    )
+                    resultNotification =
+                        ExecutionResultNotification(
+                            jobId = jobId,
+                            userId = aiOwnerUserId,
+                            status = currentStatus,
+                            sessionId = sessionId,
+                            tickNumber = tickNumber,
+                            cpuTimeSeconds = cpuTimeSeconds,
+                            memoryKb = memoryKb,
+                            exitCode = exitCode,
+                            action = action.takeIf { it.isNotBlank() },
+                            programStderr = programStderr,
+                            newMemoryData =
+                                if (currentStatus == JobStatus.SUCCESS) memoryDataForRedis
+                                else null,
+                            errorDetails = errorDetails.takeUnless { it.isNullOrBlank() },
+                            sandboxLogRef = finalLogRef,
+                            clientRequestId = request.clientRequestId,
+                            workerNodeId = applicationConfig.nodeId,
+                            submitTime = request.timestamp,
+                            startTime = startTime,
+                            endTime = Instant.now(),
+                        )
 
                     // Group notify + enqueue + cleanup in a single IO context to minimize switches
                     withContext(Dispatchers.IO + NonCancellable) {
                         tracer.withSuspendingSpan("amqp.notify_result") {
-                            resultNotifier.notifyExecutionResult(resultNotification)
+                            // Build header timestamps and deltas
+                            val pubTs = request.timestamp
+                            val delTs = deliveredTs
+                            val stTs = sandboxStartTs
+                            val dnTs = sandboxDoneTs
+                            val headers =
+                                buildMap<String, Any?> {
+                                    put("execute.pub_ts", pubTs.toString())
+                                    put("execute.delivered_ts", delTs.toString())
+                                    stTs?.let { put("execute.start_ts", it.toString()) }
+                                    dnTs?.let { put("execute.done_ts", it.toString()) }
+                                    // deltas in milliseconds
+                                    runCatching {
+                                        put(
+                                            "execute.delta_pub_to_delivered_ms",
+                                            java.time.Duration.between(pubTs, delTs).toMillis(),
+                                        )
+                                    }
+                                    runCatching {
+                                        if (stTs != null)
+                                            put(
+                                                "execute.delta_delivered_to_start_ms",
+                                                java.time.Duration.between(delTs, stTs).toMillis(),
+                                            )
+                                    }
+                                    runCatching {
+                                        if (stTs != null && dnTs != null)
+                                            put(
+                                                "execute.delta_start_to_done_ms",
+                                                java.time.Duration.between(stTs, dnTs).toMillis(),
+                                            )
+                                    }
+                                    runCatching {
+                                        if (dnTs != null)
+                                            put(
+                                                "execute.delta_pub_to_done_ms",
+                                                java.time.Duration.between(pubTs, dnTs).toMillis(),
+                                            )
+                                    }
+                                }
+                            resultNotifier.notifyExecutionResult(resultNotification, headers)
                         }
 
                         try {
                             val resultJson = objectMapper.writeValueAsString(resultNotification)
                             logger.info("Execution result for job {}: {}", jobId, resultJson)
                         } catch (e: Exception) {
-                            logger.error("Failed to serialize result notification for job $jobId", e)
+                            logger.error(
+                                "Failed to serialize result notification for job $jobId",
+                                e,
+                            )
                         }
 
                         val enqueued = resultChannel.trySend(resultNotification).isSuccess
@@ -765,9 +877,10 @@ class ExecuteService(
     }
 
     private fun scheduleAsyncLogUpload(objectKey: String, logFile: Path) {
-        val data = Files.newInputStream(logFile).use { inputStream ->
-            readStreamToByteArray(inputStream, 16 * 1024)
-        }
+        val data =
+            Files.newInputStream(logFile).use { inputStream ->
+                readStreamToByteArray(inputStream, 16 * 1024)
+            }
         val fileSize = data.size.toLong()
         appScope.launch(Dispatchers.IO + Context.current().asContextElement()) {
             try {
@@ -871,12 +984,14 @@ class ExecuteService(
                 coroutineScope {
                     val ctx = Context.current()
                     val maxOutputBytes = 16 * 1024 // 10 KB
-                    val outputGobbler = async(Dispatchers.IO + ctx.asContextElement()) {
-                        process.inputStream.use { readStreamToString(it, maxOutputBytes) }
-                    }
-                    val errorGobbler = async(Dispatchers.IO + ctx.asContextElement()) {
-                        process.errorStream.use { readStreamToString(it, maxOutputBytes) }
-                    }
+                    val outputGobbler =
+                        async(Dispatchers.IO + ctx.asContextElement()) {
+                            process.inputStream.use { readStreamToString(it, maxOutputBytes) }
+                        }
+                    val errorGobbler =
+                        async(Dispatchers.IO + ctx.asContextElement()) {
+                            process.errorStream.use { readStreamToString(it, maxOutputBytes) }
+                        }
 
                     val waitTimeoutMillis =
                         TimeUnit.SECONDS.toMillis(request.wallTimeLimitSeconds + 2)
@@ -1117,9 +1232,7 @@ class ExecuteService(
     private fun shutdown() {
         logger.info("Shutting down ExecuteService processors...")
         resultChannel.close()
-        runBlocking {
-            resultProcessors.joinAll()
-        }
+        runBlocking { resultProcessors.joinAll() }
         logger.info("All result processors stopped.")
     }
 

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/CacheEvictionListener.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/CacheEvictionListener.kt
@@ -32,7 +32,7 @@ class CacheEvictionListener(private val cacheManager: CacheManager) {
                         ),
                     key = [""],
                 )
-            ]
+            ],
     )
     fun onCacheEvict(message: CacheEvictMessage) {
         try {

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/DefaultTaskProcessor.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/DefaultTaskProcessor.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
 import io.opentelemetry.api.OpenTelemetry
 import io.opentelemetry.context.propagation.ContextPropagators
+import java.time.Instant
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
 import kotlinx.coroutines.withContext
@@ -27,7 +28,7 @@ class DefaultTaskProcessor(
 
     private val logger = LoggerFactory.getLogger(DefaultTaskProcessor::class.java)
 
-    override suspend fun processMessage(message: Message) {
+    override suspend fun processMessage(message: Message, deliveredTs: Instant) {
         val messageProperties = message.messageProperties
         val messageBody = String(message.body, Charsets.UTF_8) // Assume UTF-8 encoding
         val correlationId = messageProperties.correlationId // Use correlationId as jobId
@@ -77,7 +78,7 @@ class DefaultTaskProcessor(
                 AmqpConstants.MESSAGE_TYPE_EXECUTE -> {
                     val request: ExecutionRequest = parseMessageBody(messageBody, correlationId)
                     withContext(Dispatchers.IO) {
-                        executeService.processExecutionRequest(request, correlationId)
+                        executeService.processExecutionRequest(request, correlationId, deliveredTs)
                     }
                     logger.info(
                         "Successfully processed execution request for JobId: {}",

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/ResultNotifier.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/ResultNotifier.kt
@@ -54,15 +54,24 @@ class ResultNotifier(
         sendNotification(notification, AmqpConstants.MESSAGE_TYPE_COMPILE_RESULT, jobId.toString())
     }
 
-    suspend fun notifyExecutionResult(notification: ExecutionResultNotification) {
+    suspend fun notifyExecutionResult(
+        notification: ExecutionResultNotification,
+        headers: Map<String, Any?> = emptyMap(),
+    ) {
         sendNotification(
             notification,
             AmqpConstants.MESSAGE_TYPE_EXECUTE_RESULT,
             notification.jobId,
+            headers,
         )
     }
 
-    private suspend fun <T : Any> sendNotification(payload: T, messageType: String, jobId: String) {
+    private suspend fun <T : Any> sendNotification(
+        payload: T,
+        messageType: String,
+        jobId: String,
+        headers: Map<String, Any?> = emptyMap(),
+    ) {
         try {
             // Send notification on IO dispatcher
             withContext(Dispatchers.IO) {
@@ -71,6 +80,8 @@ class ResultNotifier(
                     message.messageProperties.correlationId = jobId // Use original jobId
                     message.messageProperties.headers[AmqpConstants.HEADER_MESSAGE_TYPE] =
                         messageType
+                    // Merge custom headers
+                    headers.forEach { (k, v) -> message.messageProperties.headers[k] = v }
 
                     propagators.textMapPropagator.inject(
                         Context.current(),

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/TaskListenerService.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/TaskListenerService.kt
@@ -45,6 +45,7 @@ class TaskListenerService(
     private fun handleMessage(message: Message, operation: String): CompletableFuture<Void?> {
         val props = message.messageProperties
         val jobId = props.correlationId ?: "[unknown_jobId-${props.deliveryTag}]"
+        val deliveredTs = java.time.Instant.now()
 
         val extracted: Context = propagator.extract(Context.current(), message, AmqpGetter)
 
@@ -80,7 +81,7 @@ class TaskListenerService(
         return applicationScope.future(ctxWithConsumer.asContextElement()) {
             ctxWithConsumer.makeCurrent().use { _: Scope ->
                 try {
-                    taskProcessor.processMessage(message)
+                    taskProcessor.processMessage(message, deliveredTs)
 
                     consumerSpan.setStatus(StatusCode.OK)
                     logger.info("Successfully processed {} task for jobId={}", operation, jobId)

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/TaskProcessor.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/TaskProcessor.kt
@@ -1,5 +1,6 @@
 package org.rucca.snake.worker.infra.amqp
 
+import java.time.Instant
 import org.springframework.amqp.core.Message
 
 /** Interface for processing tasks received from the message queue. */
@@ -14,5 +15,5 @@ interface TaskProcessor {
      * @throws Exception if processing fails critically and the message should be NACKed (or
      *   potentially retried/sent to DLQ).
      */
-    suspend fun processMessage(message: Message)
+    suspend fun processMessage(message: Message, deliveredTs: Instant)
 }

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+./mvnw clean package
+if [ $? -ne 0 ]; then
+  echo "Build failed. Please check the output for errors."
+  exit 1
+fi
+
+cp backend-controller/target/snake.controller-0.0.1-SNAPSHOT.jar backend-controller/target/snake-controller.jar
+cp backend-worker/target/snake.worker-0.0.1-SNAPSHOT.jar backend-worker/target/snake-worker.jar
+
+echo "Build completed successfully. JAR files are ready in the target directories."
+
+cd docker-compose-deploy
+sudo docker compose -f docker-compose.local.yml build
+
+if [ $? -ne 0 ]; then
+  echo "Docker build failed. Please check the output for errors."
+  exit 1
+fi
+
+sudo docker compose -f docker-compose.local.yml up -d


### PR DESCRIPTION
### Summary

- Add end-to-end timing for each execute message:
    - pub_ts (controller publish), delivered_ts (worker listener), start_ts (post-permit, pre-sandbox), done_ts (post-sandbox, pre-ack).
- Emit four Micrometer timers with p95/p99 percentiles and histograms.
- Attach timestamps and deltas to AMQP headers (no DB changes, no OpenAPI change).

### Changes

- backend-controller
    - JobSubmitService: set ExecutionRequest.timestamp at publish time and add execute.pub_ts header.
- backend-worker
    - TaskListenerService: capture delivered_ts on message receipt.
    - TaskProcessor/DefaultTaskProcessor: propagate deliveredTs to ExecuteService.
    - ExecuteService:
    - Capture `start_ts` (after nsjail permit) and `done_ts` (after sandbox completes).
    - Record timers: `job.execute.latency.publish_to_delivered`, `...delivered_to_start`, `...start_to_done`, `...publish_to_done`.
    - Timers registered once at service init, `.publishPercentiles(0.95, 0.99)` and `.publishPercentileHistogram(true)`.
- ResultNotifier: include headers in execution result messages:
    - `execute.pub_ts`, `execute.delivered_ts`, `execute.start_ts`, `execute.done_ts`
    - `execute.delta_pub_to_delivered_ms`, `..._delivered_to_start_ms`, `..._start_to_done_ms`, `..._pub_to_done_ms`

### Metrics

- Names (all tagged type=execute):
    - job.execute.latency.publish_to_delivered
    - job.execute.latency.delivered_to_start
    - job.execute.latency.start_to_done
    - job.execute.latency.publish_to_done
- Config: p95/p99 percentiles + percentile histograms enabled for Prometheus queries.
- Example PromQL:
    - histogram_quantile(0.95, sum(rate(job_execute_latency_start_to_done_seconds_bucket[5m])) by (le))
    - histogram_quantile(0.99, sum(rate(job_execute_latency_publish_to_done_seconds_bucket[5m])) by (le))

### Notes

- start_ts is recorded immediately after semaphore acquire, pre-sandbox.
- done_ts is recorded immediately when sandbox returns, pre-ACK.
- Optional follow-up: add OTel span events for the four timestamps if you want them visible in tracing UIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Improved execution observability with publish/deliver/start/done timestamps and latency metrics.
  * Result notifications enriched with timing metadata; messages include a publish timestamp header.

* Documentation
  * Added a comprehensive contributor guide covering structure, commands, style, testing, and security.

* Chores
  * Introduced a rebuild script to streamline packaging and local Docker deployment.

* Style
  * Minor formatting cleanups in message listeners and configuration (no behavioral changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->