### PR TITLE
fix(amqp): declare cache evict bindings

### DIFF
--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/config/AmqpConfig.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/config/AmqpConfig.kt
@@ -6,6 +6,7 @@ import org.springframework.amqp.core.*
 import org.springframework.amqp.rabbit.config.SimpleRabbitListenerContainerFactory
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory
 import org.springframework.amqp.rabbit.connection.ConnectionFactory
+import org.springframework.amqp.rabbit.core.RabbitAdmin
 import org.springframework.amqp.rabbit.core.RabbitTemplate
 import org.springframework.amqp.rabbit.listener.RabbitListenerContainerFactory
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer
@@ -330,5 +331,28 @@ class AmqpConfig {
         factory.setDefaultRequeueRejected(false)
 
         return factory
+    }
+
+    @Bean
+    fun rabbitAdmin(@Qualifier("consumerConnectionFactory") cf: ConnectionFactory): AmqpAdmin =
+        RabbitAdmin(cf)
+
+    @Bean
+    fun cacheEvictDeclarables(
+        @Value("\${spring.application.name:snake.worker}") appName: String,
+        @Value("\${HOSTNAME:local}") host: String,
+        @Qualifier("cacheFanoutExchange") cacheFx: FanoutExchange,
+    ): Declarables {
+        val queueName = "$appName.cache-evict.$host"
+
+        val queue = QueueBuilder.durable(queueName)
+            .withArgument("x-queue-type", "quorum")
+            .withArgument("x-max-length", 1000)
+            .withArgument("x-overflow", "drop-head")
+            .withArgument("x-message-ttl", 60000)
+            .build()
+
+        val binding = BindingBuilder.bind(queue).to(cacheFx)
+        return Declarables(queue, binding)
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved cache eviction processing by introducing a durable, per-host queue for cache invalidation events, enhancing reliability under load and reducing dropped messages.
  - Streamlined AMQP administration to ensure queues and bindings are created automatically at startup, improving stability of background processing.
  - Optimized message handling with sensible retention and TTL settings to balance performance and resource usage during spikes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->