### PR TITLE
feat(controller): rate limit for compile and execute request

### DIFF
--- a/backend-controller/pom.xml
+++ b/backend-controller/pom.xml
@@ -28,6 +28,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>
         <dependency>
@@ -220,6 +224,19 @@
             <groupId>net.logstash.logback</groupId>
             <artifactId>logstash-logback-encoder</artifactId>
             <version>8.1</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-redis-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-lettuce</artifactId>
         </dependency>
     </dependencies>
 

--- a/backend-controller/pom.xml
+++ b/backend-controller/pom.xml
@@ -238,6 +238,12 @@
             <groupId>com.bucket4j</groupId>
             <artifactId>bucket4j_jdk17-lettuce</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/ApplicationConfig.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/ApplicationConfig.kt
@@ -16,7 +16,4 @@ data class CorsProperties(var allowedOrigins: List<String> = listOf("*"))
 
 @Component
 @ConfigurationProperties(prefix = "application")
-data class ApplicationConfig(
-    var workerUrls: List<String> = listOf("http://localhost:8080"),
-    var cors: CorsProperties = CorsProperties(),
-)
+data class ApplicationConfig(var cors: CorsProperties = CorsProperties())

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/RateLimiterConfig.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/RateLimiterConfig.kt
@@ -1,0 +1,63 @@
+package org.rucca.snake.controller.config
+
+import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import io.github.bucket4j.redis.lettuce.Bucket4jLettuce
+import io.lettuce.core.RedisClient
+import io.lettuce.core.RedisURI
+import io.lettuce.core.api.StatefulConnection
+import io.lettuce.core.api.StatefulRedisConnection
+import io.lettuce.core.cluster.RedisClusterClient
+import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
+import io.lettuce.core.codec.ByteArrayCodec
+import java.time.Duration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+
+@Configuration
+class RateLimiterConfig {
+
+    @Bean(destroyMethod = "close")
+    fun bucket4jRedisConnection(
+        cf: LettuceConnectionFactory
+    ): StatefulConnection<ByteArray, ByteArray> {
+        val cluster = cf.clusterConfiguration
+        return if (cluster == null) {
+            val sc = cf.standaloneConfiguration
+            val uri = RedisURI.Builder.redis(sc.hostName, sc.port).withDatabase(sc.database).build()
+            val client = RedisClient.create(uri)
+            client.connect(ByteArrayCodec.INSTANCE)
+        } else {
+            // cluster
+            val uris =
+                cluster.clusterNodes.map {
+                    RedisURI.Builder.redis(it.host, it.port ?: 6379).build()
+                }
+            val client = RedisClusterClient.create(uris)
+            client.connect(ByteArrayCodec.INSTANCE)
+        }
+    }
+
+    @Bean
+    fun redisProxyManager(
+        bucket4jRedisConnection: StatefulConnection<ByteArray, ByteArray>
+    ): ProxyManager<ByteArray> {
+        val builder =
+            when (bucket4jRedisConnection) {
+                is StatefulRedisConnection<ByteArray, ByteArray> ->
+                    Bucket4jLettuce.casBasedBuilder(bucket4jRedisConnection)
+                is StatefulRedisClusterConnection<ByteArray, ByteArray> ->
+                    Bucket4jLettuce.casBasedBuilder(bucket4jRedisConnection)
+                else -> error("Unsupported Lettuce stateful connection type")
+            }
+
+        return builder
+            .expirationAfterWrite(
+                ExpirationAfterWriteStrategy.basedOnTimeForRefillingBucketUpToMax(
+                    Duration.ofSeconds(10)
+                )
+            )
+            .build()
+    }
+}

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/RateLimiterConfig.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/RateLimiterConfig.kt
@@ -3,6 +3,7 @@ package org.rucca.snake.controller.config
 import io.github.bucket4j.distributed.ExpirationAfterWriteStrategy
 import io.github.bucket4j.distributed.proxy.ProxyManager
 import io.github.bucket4j.redis.lettuce.Bucket4jLettuce
+import io.lettuce.core.AbstractRedisClient
 import io.lettuce.core.RedisClient
 import io.lettuce.core.RedisURI
 import io.lettuce.core.api.StatefulConnection
@@ -11,33 +12,53 @@ import io.lettuce.core.cluster.RedisClusterClient
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection
 import io.lettuce.core.codec.ByteArrayCodec
 import java.time.Duration
+import kotlin.jvm.optionals.getOrNull
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 
 @Configuration
 class RateLimiterConfig {
-
-    @Bean(destroyMethod = "close")
-    fun bucket4jRedisConnection(
-        cf: LettuceConnectionFactory
-    ): StatefulConnection<ByteArray, ByteArray> {
+    @Bean(destroyMethod = "shutdown")
+    fun bucket4jLettuceClient(cf: LettuceConnectionFactory): AbstractRedisClient {
         val cluster = cf.clusterConfiguration
         return if (cluster == null) {
             val sc = cf.standaloneConfiguration
-            val uri = RedisURI.Builder.redis(sc.hostName, sc.port).withDatabase(sc.database).build()
-            val client = RedisClient.create(uri)
-            client.connect(ByteArrayCodec.INSTANCE)
+            val uri =
+                RedisURI.Builder.redis(sc.hostName, sc.port)
+                    .apply {
+                        withDatabase(sc.database)
+                        val username = sc.username
+                        val password = sc.password.toOptional().getOrNull()
+                        if (username != null && password != null) {
+                            withAuthentication(username, password)
+                        } else if (password != null) {
+                            withPassword(password)
+                        }
+                        withSsl(cf.isUseSsl)
+                    }
+                    .build()
+            RedisClient.create(uri)
         } else {
-            // cluster
             val uris =
                 cluster.clusterNodes.map {
-                    RedisURI.Builder.redis(it.host, it.port ?: 6379).build()
+                    RedisURI.Builder.redis(it.host, it.port ?: 6379)
+                        // TODO: support authentication
+                        .build()
                 }
-            val client = RedisClusterClient.create(uris)
-            client.connect(ByteArrayCodec.INSTANCE)
+            RedisClusterClient.create(uris)
         }
     }
+
+    @Bean(destroyMethod = "close")
+    fun bucket4jRedisConnection(
+        bucket4jLettuceClient: AbstractRedisClient
+    ): StatefulConnection<ByteArray, ByteArray> =
+        when (bucket4jLettuceClient) {
+            is RedisClient -> bucket4jLettuceClient.connect(ByteArrayCodec.INSTANCE)
+            is RedisClusterClient -> bucket4jLettuceClient.connect(ByteArrayCodec.INSTANCE)
+            else -> error("Unsupported Lettuce client")
+        }
 
     @Bean
     fun redisProxyManager(
@@ -47,8 +68,10 @@ class RateLimiterConfig {
             when (bucket4jRedisConnection) {
                 is StatefulRedisConnection<ByteArray, ByteArray> ->
                     Bucket4jLettuce.casBasedBuilder(bucket4jRedisConnection)
+
                 is StatefulRedisClusterConnection<ByteArray, ByteArray> ->
                     Bucket4jLettuce.casBasedBuilder(bucket4jRedisConnection)
+
                 else -> error("Unsupported Lettuce stateful connection type")
             }
 

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/WebConfig.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/WebConfig.kt
@@ -13,6 +13,7 @@ class WebConfig(private val applicationConfig: ApplicationConfig) : WebMvcConfig
             .allowedOrigins(*applicationConfig.cors.allowedOrigins.toTypedArray())
             .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
             .allowedHeaders("*")
+            .exposedHeaders("Retry-After", "RateLimit", "RateLimit-Policy")
             .maxAge(3600)
     }
 }

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
@@ -15,6 +15,7 @@ import org.rucca.snake.controller.domain.model.ApiResponse
 import org.rucca.snake.controller.domain.service.JobFlowService
 import org.rucca.snake.controller.domain.service.JobQueryService
 import org.rucca.snake.controller.domain.service.JobSubmitService
+import org.rucca.snake.controller.infra.throttle.RateLimited
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -43,6 +44,7 @@ class CompileController(
 
     @Guard("submit", "program")
     @PostMapping(consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @RateLimited("compilation")
     suspend fun submitCompileRequest(
         @RequestPart("sourceFile") sourceFile: MultipartFile
     ): ResponseEntity<ApiResponse> {

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
@@ -20,6 +20,7 @@ import org.rucca.snake.controller.domain.model.ApiResponse
 import org.rucca.snake.controller.domain.model.BatchExecutionItem
 import org.rucca.snake.controller.domain.service.JobFlowService
 import org.rucca.snake.controller.domain.service.JobSubmitService
+import org.rucca.snake.controller.infra.throttle.RateLimited
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -52,6 +53,8 @@ class ExecuteController(
 
     @Guard("execute", "program")
     @PostMapping("/batch")
+    @RateLimited("execution-jobs")
+    @RateLimited("execution-frequency")
     suspend fun submitBatchExecutionRequest(
         @RequestBody requests: List<BatchExecutionItem>
     ): ResponseEntity<ApiResponse> {

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/exception/GlobalErrorHandler.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/exception/GlobalErrorHandler.kt
@@ -9,8 +9,6 @@
 
 package org.rucca.snake.controller.infra.exception
 
-import jakarta.servlet.http.HttpServletResponse
-import java.util.concurrent.TimeUnit
 import org.rucca.cheese.auth.error.BaseError
 import org.rucca.snake.controller.domain.model.ApiError
 import org.rucca.snake.controller.domain.model.ApiResponse
@@ -41,20 +39,18 @@ class GlobalExceptionHandler {
     // --- 4xx Client Errors ---
 
     @ExceptionHandler(RateLimitExceededException::class)
-    fun handleRateLimitExceeded(
-        ex: RateLimitExceededException,
-        response: HttpServletResponse,
-    ): ResponseEntity<ApiResponse> {
+    fun handleRateLimitExceeded(ex: RateLimitExceededException): ResponseEntity<ApiResponse> {
+        val nanos = ex.nanosToWaitForRefill
         val retryAfterSeconds =
-            TimeUnit.NANOSECONDS.toSeconds(ex.nanosToWaitForRefill).coerceAtLeast(1)
-
-        response.setHeader("Retry-After", retryAfterSeconds.toString())
+            (((nanos + 999_999_999) / 1_000_000_000).coerceAtLeast(1)).toString()
 
         val apiError = ApiError(type = "RATE_LIMIT_EXCEEDED", details = ex.message)
         val apiResponse =
             ApiResponse.Error(code = 429, message = "Too Many Requests", error = apiError)
 
-        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(apiResponse)
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+            .header("Retry-After", retryAfterSeconds)
+            .body(apiResponse)
     }
 
     // Handle @Valid validation failures on request bodies/params

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/exception/GlobalErrorHandler.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/exception/GlobalErrorHandler.kt
@@ -9,9 +9,13 @@
 
 package org.rucca.snake.controller.infra.exception
 
+import jakarta.servlet.http.HttpServletResponse
+import java.util.concurrent.TimeUnit
 import org.rucca.cheese.auth.error.BaseError
 import org.rucca.snake.controller.domain.model.ApiError
+import org.rucca.snake.controller.domain.model.ApiResponse
 import org.rucca.snake.controller.domain.model.ErrorResponse
+import org.rucca.snake.controller.infra.throttle.RateLimitExceededException
 import org.slf4j.LoggerFactory
 import org.springframework.amqp.AmqpException
 import org.springframework.dao.DataAccessException
@@ -35,6 +39,23 @@ class GlobalExceptionHandler {
     private val logger = LoggerFactory.getLogger(GlobalExceptionHandler::class.java)
 
     // --- 4xx Client Errors ---
+
+    @ExceptionHandler(RateLimitExceededException::class)
+    fun handleRateLimitExceeded(
+        ex: RateLimitExceededException,
+        response: HttpServletResponse,
+    ): ResponseEntity<ApiResponse> {
+        val retryAfterSeconds =
+            TimeUnit.NANOSECONDS.toSeconds(ex.nanosToWaitForRefill).coerceAtLeast(1)
+
+        response.setHeader("Retry-After", retryAfterSeconds.toString())
+
+        val apiError = ApiError(type = "RATE_LIMIT_EXCEEDED", details = ex.message)
+        val apiResponse =
+            ApiResponse.Error(code = 429, message = "Too Many Requests", error = apiError)
+
+        return ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS).body(apiResponse)
+    }
 
     // Handle @Valid validation failures on request bodies/params
     @ExceptionHandler(MethodArgumentNotValidException::class)

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimitExceededException.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimitExceededException.kt
@@ -1,0 +1,9 @@
+package org.rucca.snake.controller.infra.throttle
+
+/**
+ * 当速率限制被触发时抛出的自定义异常。
+ *
+ * @param nanosToWaitForRefill 需要等待多少纳秒才能有新的令牌。
+ */
+class RateLimitExceededException(message: String, val nanosToWaitForRefill: Long) :
+    RuntimeException(message)

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimited.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimited.kt
@@ -1,0 +1,15 @@
+package org.rucca.snake.controller.infra.throttle
+
+/** @RateLimited 注解的容器，使其可以重复使用。 */
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RateLimits(val value: Array<RateLimited>)
+
+/** 声明一个可重复的、基于SpEL的速率限制规则。 */
+@JvmRepeatable(RateLimits::class)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RateLimited(
+    /** The name of the rate limiting policy defined in application.yml. */
+    val value: String
+)

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterAspect.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterAspect.kt
@@ -3,9 +3,10 @@ package org.rucca.snake.controller.infra.throttle
 import io.github.bucket4j.BucketConfiguration
 import io.github.bucket4j.ConsumptionProbe
 import io.github.bucket4j.distributed.proxy.ProxyManager
+import jakarta.servlet.http.HttpServletResponse
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
-import java.util.concurrent.TimeUnit
+import kotlin.math.max
 import org.aspectj.lang.ProceedingJoinPoint
 import org.aspectj.lang.annotation.Around
 import org.aspectj.lang.annotation.Aspect
@@ -13,6 +14,7 @@ import org.aspectj.lang.reflect.MethodSignature
 import org.rucca.cheese.auth.AuthenticationService
 import org.slf4j.LoggerFactory
 import org.springframework.expression.Expression
+import org.springframework.expression.ParseException
 import org.springframework.expression.spel.standard.SpelExpressionParser
 import org.springframework.expression.spel.support.StandardEvaluationContext
 import org.springframework.stereotype.Component
@@ -49,6 +51,7 @@ class RateLimiterAspect(
 
         var mostRelevantProbe: ConsumptionProbe? = null
         var mostRelevantPolicy: Policy? = null
+        var mostRelevantPolicyName: String? = null
 
         for (policyName in policyNames) {
             val policy =
@@ -61,6 +64,12 @@ class RateLimiterAspect(
             val tokensToConsume = parseSpel(policy.tokensExpression, context, Long::class.java)
 
             if (key == null || tokensToConsume == null || tokensToConsume == 0L) {
+                logger.warn(
+                    "Skipping rate limit policy '{}': key={}, tokensToConsume={}",
+                    policyName,
+                    key,
+                    tokensToConsume,
+                )
                 continue
             }
 
@@ -84,31 +93,64 @@ class RateLimiterAspect(
                     mostRelevantProbe == null ||
                         (probe.remainingTokens * 100 / policy.capacity) <
                             (mostRelevantProbe.remainingTokens * 100 /
-                                mostRelevantPolicy!!.capacity)
+                                (mostRelevantPolicy?.capacity ?: policy.capacity))
                 ) {
                     mostRelevantProbe = probe
                     mostRelevantPolicy = policy
+                    mostRelevantPolicyName = policyName
                 }
             } else {
-                setRateLimitHeaders(probe, policy)
+                setRateLimitHeaders(probe, policy, policyName)
                 throw RateLimitExceededException("Rate limit exceeded.", probe.nanosToWaitForRefill)
             }
         }
 
-        setRateLimitHeaders(mostRelevantProbe, mostRelevantPolicy)
+        setRateLimitHeaders(mostRelevantProbe, mostRelevantPolicy, mostRelevantPolicyName)
         return joinPoint.proceed()
     }
 
-    private fun setRateLimitHeaders(probe: ConsumptionProbe?, policy: Policy?) {
-        if (probe == null || policy == null) return
+    private fun appendHeader(response: HttpServletResponse, name: String, value: String) {
+        val existing = response.getHeader(name)
+        if (existing.isNullOrBlank()) {
+            response.setHeader(name, value)
+        } else {
+            response.setHeader(name, "$existing, $value")
+        }
+    }
+
+    private fun setRateLimitHeaders(
+        probe: ConsumptionProbe?,
+        policy: Policy?,
+        policyName: String?,
+    ) {
         val response =
             (RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes)?.response
                 ?: return
 
-        response.setHeader("RateLimit-Limit", policy.capacity.toString())
-        response.setHeader("RateLimit-Remaining", probe.remainingTokens.toString())
-        val resetSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.nanosToWaitForRefill)
-        response.setHeader("RateLimit-Reset", resetSeconds.toString())
+        val name = policyName?.takeIf { it.isNotBlank() } ?: "default"
+
+        policy?.let { p ->
+            val perUnitSeconds = p.refillUnit.duration.seconds
+            val windowSeconds = max(1L, perUnitSeconds * p.refillPeriod)
+
+            val policyItem = """"$name";q=${p.refillRate};w=$windowSeconds"""
+            appendHeader(response, "RateLimit-Policy", policyItem)
+        }
+
+        probe?.let { pr ->
+            val remaining = pr.remainingTokens.coerceAtLeast(0)
+            val nanos = pr.nanosToWaitForRefill
+            val tSeconds: Long? =
+                if (nanos > 0) {
+                    (nanos + 999_999_999L) / 1_000_000_000L
+                } else null
+
+            val rateLimitItem = buildString {
+                append("\"").append(name).append("\";r=").append(remaining)
+                tSeconds?.let { append(";t=").append(it) }
+            }
+            appendHeader(response, "RateLimit", rateLimitItem)
+        }
     }
 
     private fun createEvaluationContext(joinPoint: ProceedingJoinPoint): StandardEvaluationContext {
@@ -137,7 +179,16 @@ class RateLimiterAspect(
                 }
             expression.getValue(context, desiredResultType)
         } catch (e: Exception) {
-            logger.error("Failed to parse SpEL expression: '${expressionString}'", e)
+            logger.error(
+                "Failed to evaluate SpEL expression '${expressionString}': ${e.message}",
+                e,
+            )
+            if (e is ParseException) {
+                throw IllegalStateException(
+                    "Invalid SpEL expression in configuration: $expressionString",
+                    e,
+                )
+            }
             null
         }
     }

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterAspect.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterAspect.kt
@@ -1,0 +1,144 @@
+package org.rucca.snake.controller.infra.throttle
+
+import io.github.bucket4j.BucketConfiguration
+import io.github.bucket4j.ConsumptionProbe
+import io.github.bucket4j.distributed.proxy.ProxyManager
+import java.time.Duration
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.TimeUnit
+import org.aspectj.lang.ProceedingJoinPoint
+import org.aspectj.lang.annotation.Around
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.reflect.MethodSignature
+import org.rucca.cheese.auth.AuthenticationService
+import org.slf4j.LoggerFactory
+import org.springframework.expression.Expression
+import org.springframework.expression.spel.standard.SpelExpressionParser
+import org.springframework.expression.spel.support.StandardEvaluationContext
+import org.springframework.stereotype.Component
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
+
+@Aspect
+@Component
+class RateLimiterAspect(
+    private val redisProxyManager: ProxyManager<ByteArray>,
+    private val authenticationService: AuthenticationService,
+    private val properties: RateLimiterProperties,
+) {
+    private val logger = LoggerFactory.getLogger(RateLimiterAspect::class.java)
+    private val expressionParser = SpelExpressionParser()
+    private val expressionCache = ConcurrentHashMap<String, Expression>()
+
+    @Around(
+        "@annotation(org.rucca.snake.controller.infra.throttle.RateLimited) || @annotation(org.rucca.snake.controller.infra.throttle.RateLimits)"
+    )
+    fun rateLimit(joinPoint: ProceedingJoinPoint): Any? {
+        val signature = joinPoint.signature as MethodSignature
+        val method = signature.method
+
+        val policyNames = mutableListOf<String>()
+        method.getAnnotation(RateLimits::class.java)?.let { anno ->
+            policyNames.addAll(anno.value.map { it.value })
+        }
+        method.getAnnotation(RateLimited::class.java)?.let { anno -> policyNames.add(anno.value) }
+
+        if (policyNames.isEmpty()) return joinPoint.proceed()
+
+        val context = createEvaluationContext(joinPoint)
+
+        var mostRelevantProbe: ConsumptionProbe? = null
+        var mostRelevantPolicy: Policy? = null
+
+        for (policyName in policyNames) {
+            val policy =
+                properties.policies[policyName]
+                    ?: throw IllegalStateException(
+                        "Rate limiting policy '$policyName' not found in configuration."
+                    )
+
+            val key = parseSpel(policy.keyExpression, context, String::class.java)
+            val tokensToConsume = parseSpel(policy.tokensExpression, context, Long::class.java)
+
+            if (key == null || tokensToConsume == null || tokensToConsume == 0L) {
+                continue
+            }
+
+            val configuration =
+                BucketConfiguration.builder()
+                    .addLimit { limit ->
+                        limit
+                            .capacity(policy.capacity)
+                            .refillIntervally(
+                                policy.refillRate,
+                                Duration.of(policy.refillPeriod, policy.refillUnit),
+                            )
+                    }
+                    .build()
+
+            val bucket = redisProxyManager.getProxy(key.toByteArray()) { configuration }
+            val probe = bucket.tryConsumeAndReturnRemaining(tokensToConsume)
+
+            if (probe.isConsumed) {
+                if (
+                    mostRelevantProbe == null ||
+                        (probe.remainingTokens * 100 / policy.capacity) <
+                            (mostRelevantProbe.remainingTokens * 100 /
+                                mostRelevantPolicy!!.capacity)
+                ) {
+                    mostRelevantProbe = probe
+                    mostRelevantPolicy = policy
+                }
+            } else {
+                setRateLimitHeaders(probe, policy)
+                throw RateLimitExceededException("Rate limit exceeded.", probe.nanosToWaitForRefill)
+            }
+        }
+
+        setRateLimitHeaders(mostRelevantProbe, mostRelevantPolicy)
+        return joinPoint.proceed()
+    }
+
+    private fun setRateLimitHeaders(probe: ConsumptionProbe?, policy: Policy?) {
+        if (probe == null || policy == null) return
+        val response =
+            (RequestContextHolder.getRequestAttributes() as? ServletRequestAttributes)?.response
+                ?: return
+
+        response.setHeader("RateLimit-Limit", policy.capacity.toString())
+        response.setHeader("RateLimit-Remaining", probe.remainingTokens.toString())
+        val resetSeconds = TimeUnit.NANOSECONDS.toSeconds(probe.nanosToWaitForRefill)
+        response.setHeader("RateLimit-Reset", resetSeconds.toString())
+    }
+
+    private fun createEvaluationContext(joinPoint: ProceedingJoinPoint): StandardEvaluationContext {
+        val context = StandardEvaluationContext()
+        val signature = joinPoint.signature as MethodSignature
+        val parameterNames = signature.parameterNames
+        val args = joinPoint.args
+
+        for (i in parameterNames.indices) {
+            context.setVariable(parameterNames[i], args[i])
+        }
+
+        context.setVariable("userId", authenticationService.getCurrentUserId())
+        return context
+    }
+
+    private fun <T> parseSpel(
+        expressionString: String,
+        context: StandardEvaluationContext,
+        desiredResultType: Class<T>,
+    ): T? {
+        return try {
+            val expression =
+                expressionCache.computeIfAbsent(expressionString) {
+                    expressionParser.parseExpression(it)
+                }
+            expression.getValue(context, desiredResultType)
+        } catch (e: Exception) {
+            logger.error("Failed to parse SpEL expression: '${expressionString}'", e)
+            null
+        }
+    }
+}

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterProperties.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterProperties.kt
@@ -1,0 +1,19 @@
+package org.rucca.snake.controller.infra.throttle
+
+import java.time.temporal.ChronoUnit
+import org.intellij.lang.annotations.Language
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "rate-limiter")
+data class RateLimiterProperties(var policies: Map<String, Policy> = emptyMap())
+
+data class Policy(
+    var capacity: Long,
+    var refillRate: Long,
+    var refillPeriod: Long = 1,
+    var refillUnit: ChronoUnit = ChronoUnit.MINUTES,
+    @Language("SpEL") var keyExpression: String,
+    @Language("SpEL") var tokensExpression: String = "1",
+)

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterProperties.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterProperties.kt
@@ -1,19 +1,23 @@
 package org.rucca.snake.controller.infra.throttle
 
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Positive
 import java.time.temporal.ChronoUnit
 import org.intellij.lang.annotations.Language
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
+import org.springframework.validation.annotation.Validated
 
 @Component
+@Validated
 @ConfigurationProperties(prefix = "rate-limiter")
 data class RateLimiterProperties(var policies: Map<String, Policy> = emptyMap())
 
 data class Policy(
-    var capacity: Long,
-    var refillRate: Long,
-    var refillPeriod: Long = 1,
+    @Positive var capacity: Long,
+    @Positive var refillRate: Long,
+    @Positive var refillPeriod: Long = 1,
     var refillUnit: ChronoUnit = ChronoUnit.MINUTES,
-    @Language("SpEL") var keyExpression: String,
-    @Language("SpEL") var tokensExpression: String = "1",
+    @NotBlank @Language("SpEL") var keyExpression: String,
+    @NotBlank @Language("SpEL") var tokensExpression: String = "1",
 )

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterProperties.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/infra/throttle/RateLimiterProperties.kt
@@ -1,5 +1,6 @@
 package org.rucca.snake.controller.infra.throttle
 
+import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.Positive
 import java.time.temporal.ChronoUnit
@@ -11,7 +12,7 @@ import org.springframework.validation.annotation.Validated
 @Component
 @Validated
 @ConfigurationProperties(prefix = "rate-limiter")
-data class RateLimiterProperties(var policies: Map<String, Policy> = emptyMap())
+data class RateLimiterProperties(@field:Valid var policies: Map<String, Policy> = emptyMap())
 
 data class Policy(
     @Positive var capacity: Long,

--- a/backend-controller/src/main/resources/application.yml
+++ b/backend-controller/src/main/resources/application.yml
@@ -63,7 +63,6 @@ cheese-auth:
   auth-server-url: ${CHEESE_AUTH_SERVER_URL:http://localhost:8080}
 
 application:
-  worker-urls: http://localhost:8081
   cors:
     allowed-origins:
       - http://localhost:3000
@@ -95,3 +94,34 @@ minio:
   accessKey: ${MINIO_ACCESS_KEY:minioadmin}
   secretKey: ${MINIO_SECRET_KEY:minioadmin}
   bucketName: ${MINIO_BUCKET_NAME:oj-programs}
+
+# ===============================================
+# Rate Limiter Configuration
+# ===============================================
+rate-limiter:
+  # 定义所有可用的限流策略
+  policies:
+
+    compilation:
+      capacity: 10                    # 桶容量/突发容量: 10
+      refill-rate: 10                 # 补充速率: 10
+      refill-period: 1                # 补充周期: 1
+      refill-unit: MINUTES            # 补充单位: 分钟
+      key-expression: "'compilation:' + #userId" # Redis Key表达式
+      tokens-expression: "1"        # 每次请求固定消耗1个令牌
+
+    execution-jobs:
+      capacity: 800                   # 桶容量/突发容量: 800 jobs
+      refill-rate: 400                # 补充速率: 400 jobs
+      refill-period: 1                # 补充周期: 1
+      refill-unit: SECONDS            # 补充单位: 秒
+      key-expression: "'execution_jobs:' + #userId" # Redis Key表达式
+      tokens-expression: "#requests.size()" # 消耗的令牌数 = 请求体中requests列表的大小
+
+    execution-frequency:
+      capacity: 100                   # 桶容量/突发容量: 100 requests
+      refill-rate: 50                 # 补充速率: 50 requests
+      refill-period: 1                # 补充周期: 1
+      refill-unit: SECONDS            # 补充单位: 秒
+      key-expression: "'execution_freq:' + #userId" # Redis Key表达式
+      tokens-expression: "1"        # 每次请求固定消耗1个令牌

--- a/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/CacheEvictionListener.kt
+++ b/backend-worker/src/main/kotlin/org/rucca/snake/worker/infra/amqp/CacheEvictionListener.kt
@@ -3,7 +3,6 @@ package org.rucca.snake.worker.infra.amqp
 import org.rucca.snake.common.domain.model.CacheEvictMessage
 import org.rucca.snake.worker.domain.service.CacheManager
 import org.slf4j.LoggerFactory
-import org.springframework.amqp.rabbit.annotation.Argument
 import org.springframework.amqp.rabbit.annotation.Exchange
 import org.springframework.amqp.rabbit.annotation.Queue
 import org.springframework.amqp.rabbit.annotation.QueueBinding

--- a/docker-compose-deploy/docker-compose.local.yml
+++ b/docker-compose-deploy/docker-compose.local.yml
@@ -28,15 +28,10 @@ services:
       backend-controller:
         condition: service_healthy
     volumes:
-      - type: tmpfs
-        target: /app/data
-        tmpfs:
-          size: 1G
-      - type: tmpfs
-        target: /app/cache
-        tmpfs:
-          size: 2G
       - ./application-worker.yml:/app/config/application.yml:ro
+    tmpfs:
+      - /app/data:exec,size=1G
+      - /app/cache:exec,size=2G
     logging:
       driver: json-file
       options:

--- a/docker-compose-deploy/docker-compose.yml
+++ b/docker-compose-deploy/docker-compose.yml
@@ -138,15 +138,10 @@ services:
       backend-controller:
         condition: service_healthy
     volumes:
-      - type: tmpfs
-        target: /app/data
-        tmpfs:
-          size: 1G
-      - type: tmpfs
-        target: /app/cache
-        tmpfs:
-          size: 2G
       - ./application-worker.yml:/app/config/application.yml:ro
+    tmpfs:
+      - /app/data:exec,size=1G
+      - /app/cache:exec,size=2G
     logging:
       driver: json-file
       options:
@@ -247,6 +242,8 @@ services:
   cheese-auth:
     image: ${CHEESE_AUTH_IMAGE:-ghcr.io/sageseekersociety/cheese-auth:${CHEESE_AUTH_TAG:-main}}
     env_file: .env
+    environment:
+      - "PORT=8080"
     volumes:
       - type: volume
         source: cheese_auth_uploads

--- a/pom.xml
+++ b/pom.xml
@@ -31,9 +31,9 @@
     <properties>
         <!-- 统一管理版本号 -->
         <java.version>21</java.version>
-        <spring.boot.version>3.4.4</spring.boot.version>
+        <spring.boot.version>3.5.5</spring.boot.version>
         <!-- 确保统一 -->
-        <kotlin.version>2.1.10</kotlin.version>
+        <kotlin.version>2.1.20</kotlin.version>
         <!-- 确保统一 -->
         <kotlinx-coroutines.version>1.10.1</kotlinx-coroutines.version>
         <minio.version>8.5.17</minio.version>
@@ -54,6 +54,7 @@
         <jakarta-validation-api.version>3.1.1</jakarta-validation-api.version>
         <jakarta-servlet-api.version>6.1.0</jakarta-servlet-api.version>
         <opentelemetry-instrumentation.version>2.19.0</opentelemetry-instrumentation.version>
+        <bucket4j.version>8.15.0</bucket4j.version>
     </properties>
 
     <!-- 统一依赖管理 (子模块按需引用，无需指定版本) -->
@@ -73,6 +74,22 @@
                 <version>${opentelemetry-instrumentation.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.bucket4j</groupId>
+                <artifactId>bucket4j_jdk17-core</artifactId>
+                <version>${bucket4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bucket4j</groupId>
+                <artifactId>bucket4j_jdk17-redis-common</artifactId>
+                <version>${bucket4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.bucket4j</groupId>
+                <artifactId>bucket4j_jdk17-lettuce</artifactId>
+                <version>${bucket4j.version}</version>
             </dependency>
 
             <!-- 数据库相关 -->

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.4</version>
+        <version>3.5.5</version>
         <!-- 保持和子模块一致 -->
         <relativePath/>
         <!-- lookup parent from repository -->
@@ -31,7 +31,6 @@
     <properties>
         <!-- 统一管理版本号 -->
         <java.version>21</java.version>
-        <spring.boot.version>3.5.5</spring.boot.version>
         <!-- 确保统一 -->
         <kotlin.version>2.1.20</kotlin.version>
         <!-- 确保统一 -->


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added rate limiting to compile and batch execution endpoints.
  - Responses now include RateLimit, RateLimit-Policy, and Retry-After headers; 429 Too Many Requests returned with clear wait time when limits are exceeded.
  - CORS now exposes these headers to browsers.

- Chores
  - Upgraded framework and language versions; refreshed dependencies.
  - docker-compose updates: simplified tmpfs mounts and added PORT env for an auth service.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->