### PR TITLE
feat: system close time

### DIFF
--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/SubmissionPolicyProperties.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/SubmissionPolicyProperties.kt
@@ -1,0 +1,12 @@
+package org.rucca.snake.controller.config
+
+import java.time.Instant
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.stereotype.Component
+
+@Component
+@ConfigurationProperties(prefix = "submission-policy")
+data class SubmissionPolicyProperties(
+    var systemCloseAt: Instant? = null,
+    var executeSubmitWhitelist: Set<Long> = emptySet(),
+)

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/SubmissionPolicyProperties.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/config/SubmissionPolicyProperties.kt
@@ -1,12 +1,12 @@
 package org.rucca.snake.controller.config
 
-import java.time.Instant
+import java.time.OffsetDateTime
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.stereotype.Component
 
 @Component
 @ConfigurationProperties(prefix = "submission-policy")
 data class SubmissionPolicyProperties(
-    var systemCloseAt: Instant? = null,
+    var systemCloseAt: OffsetDateTime? = null,
     var executeSubmitWhitelist: Set<Long> = emptySet(),
 )

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
@@ -51,25 +51,31 @@ class CompileController(
     suspend fun submitCompileRequest(
         @RequestPart("sourceFile") sourceFile: MultipartFile
     ): ResponseEntity<ApiResponse> {
-        // Check system close time
-        submissionPolicy.systemCloseAt?.let { closeAt ->
-            if (Instant.now().isAfter(closeAt) || Instant.now() == closeAt) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(
-                        ApiResponse.Error(
-                            code = 403,
-                            message = "System is closed for submissions.",
-                            error =
-                                ApiError(
-                                    type = "SYSTEM_CLOSED",
-                                    details = "Submissions are disabled after close time.",
-                                ),
+        val userId = authenticationService.getCurrentUserId()
+
+        // After close time: only whitelist can submit; before close: no whitelist restriction
+        submissionPolicy.systemCloseAt?.toInstant()?.let { closeAt ->
+            val now = Instant.now()
+            val afterClose = !now.isBefore(closeAt)
+            if (afterClose) {
+                val whitelist = submissionPolicy.executeSubmitWhitelist
+                if (whitelist.isEmpty() || !whitelist.contains(userId)) {
+                    return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                        .body(
+                            ApiResponse.Error(
+                                code = 403,
+                                message = "System is closed; only whitelisted users may submit.",
+                                error =
+                                    ApiError(
+                                        type = "SYSTEM_CLOSED",
+                                        details =
+                                            "Submitter is not in whitelist after close time.",
+                                    ),
+                            )
                         )
-                    )
+                }
             }
         }
-
-        val userId = authenticationService.getCurrentUserId()
 
         if (sourceFile.isEmpty) {
             return ResponseEntity.badRequest()

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
@@ -3,6 +3,7 @@ package org.rucca.snake.controller.domain.controller
 import jakarta.annotation.PreDestroy
 import java.io.IOException
 import java.time.Duration
+import java.time.Instant
 import java.util.*
 import kotlin.coroutines.cancellation.CancellationException
 import kotlin.time.Duration.Companion.seconds
@@ -10,6 +11,7 @@ import kotlinx.coroutines.*
 import org.rucca.cheese.auth.AuthenticationService
 import org.rucca.cheese.auth.annotation.Guard
 import org.rucca.snake.common.utils.UuidV7
+import org.rucca.snake.controller.config.SubmissionPolicyProperties
 import org.rucca.snake.controller.domain.model.ApiError
 import org.rucca.snake.controller.domain.model.ApiResponse
 import org.rucca.snake.controller.domain.service.JobFlowService
@@ -31,6 +33,7 @@ class CompileController(
     private val jobFlowService: JobFlowService,
     private val authenticationService: AuthenticationService,
     private val jobQueryService: JobQueryService,
+    private val submissionPolicy: SubmissionPolicyProperties,
 ) {
     private val logger = LoggerFactory.getLogger(CompileController::class.java)
 
@@ -48,6 +51,24 @@ class CompileController(
     suspend fun submitCompileRequest(
         @RequestPart("sourceFile") sourceFile: MultipartFile
     ): ResponseEntity<ApiResponse> {
+        // Check system close time
+        submissionPolicy.systemCloseAt?.let { closeAt ->
+            if (Instant.now().isAfter(closeAt) || Instant.now() == closeAt) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(
+                        ApiResponse.Error(
+                            code = 403,
+                            message = "System is closed for submissions.",
+                            error =
+                                ApiError(
+                                    type = "SYSTEM_CLOSED",
+                                    details = "Submissions are disabled after close time.",
+                                ),
+                        )
+                    )
+            }
+        }
+
         val userId = authenticationService.getCurrentUserId()
 
         if (sourceFile.isEmpty) {

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/CompileController.kt
@@ -68,8 +68,7 @@ class CompileController(
                                 error =
                                     ApiError(
                                         type = "SYSTEM_CLOSED",
-                                        details =
-                                            "Submitter is not in whitelist after close time.",
+                                        details = "Submitter is not in whitelist after close time.",
                                     ),
                             )
                         )

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
@@ -7,6 +7,7 @@ import io.opentelemetry.extension.kotlin.asContextElement
 import jakarta.annotation.PreDestroy
 import java.io.IOException
 import java.time.Duration
+import java.time.Instant
 import java.util.*
 import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.*
@@ -15,6 +16,7 @@ import org.apache.catalina.connector.ClientAbortException
 import org.rucca.cheese.auth.AuthenticationService
 import org.rucca.cheese.auth.annotation.Guard
 import org.rucca.snake.common.utils.UuidV7
+import org.rucca.snake.controller.config.SubmissionPolicyProperties
 import org.rucca.snake.controller.domain.model.ApiError
 import org.rucca.snake.controller.domain.model.ApiResponse
 import org.rucca.snake.controller.domain.model.BatchExecutionItem
@@ -34,6 +36,7 @@ class ExecuteController(
     private val jobSubmitService: JobSubmitService,
     private val jobFlowService: JobFlowService,
     private val authenticationService: AuthenticationService,
+    private val submissionPolicy: SubmissionPolicyProperties,
     openTelemetry: OpenTelemetry,
 ) {
     private val logger = LoggerFactory.getLogger(ExecuteController::class.java)
@@ -58,6 +61,25 @@ class ExecuteController(
     suspend fun submitBatchExecutionRequest(
         @RequestBody requests: List<BatchExecutionItem>
     ): ResponseEntity<ApiResponse> {
+        // Check system close time
+        submissionPolicy.systemCloseAt?.let { closeAt ->
+            val now = Instant.now()
+            if (now.isAfter(closeAt) || now == closeAt) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(
+                        ApiResponse.Error(
+                            code = 403,
+                            message = "System is closed for submissions.",
+                            error =
+                                ApiError(
+                                    type = "SYSTEM_CLOSED",
+                                    details = "Submissions are disabled after close time.",
+                                ),
+                        )
+                    )
+            }
+        }
+
         if (requests.isEmpty()) {
             return ResponseEntity.badRequest()
                 .body(
@@ -72,6 +94,23 @@ class ExecuteController(
 
         try {
             val currentUserId = getCurrentUserId() // Get current user ID
+
+            // Execute submit whitelist check (submitter-based)
+            val whitelist = submissionPolicy.executeSubmitWhitelist
+            if (whitelist.isNotEmpty() && !whitelist.contains(currentUserId)) {
+                return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                    .body(
+                        ApiResponse.Error(
+                            code = 403,
+                            message = "You are not allowed to submit execution requests.",
+                            error =
+                                ApiError(
+                                    type = "EXECUTE_SUBMIT_NOT_ALLOWED",
+                                    details = "Submitter is not in whitelist.",
+                                ),
+                        )
+                    )
+            }
             val firstSessionId = requests.firstOrNull()?.sessionId
 
             // Ensure all other items in 'requests' have the SAME sessionId.

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
@@ -61,24 +61,6 @@ class ExecuteController(
     suspend fun submitBatchExecutionRequest(
         @RequestBody requests: List<BatchExecutionItem>
     ): ResponseEntity<ApiResponse> {
-        // Check system close time
-        submissionPolicy.systemCloseAt?.let { closeAt ->
-            val now = Instant.now()
-            if (now.isAfter(closeAt) || now == closeAt) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(
-                        ApiResponse.Error(
-                            code = 403,
-                            message = "System is closed for submissions.",
-                            error =
-                                ApiError(
-                                    type = "SYSTEM_CLOSED",
-                                    details = "Submissions are disabled after close time.",
-                                ),
-                        )
-                    )
-            }
-        }
 
         if (requests.isEmpty()) {
             return ResponseEntity.badRequest()
@@ -95,21 +77,28 @@ class ExecuteController(
         try {
             val currentUserId = getCurrentUserId() // Get current user ID
 
-            // Execute submit whitelist check (submitter-based)
-            val whitelist = submissionPolicy.executeSubmitWhitelist
-            if (whitelist.isNotEmpty() && !whitelist.contains(currentUserId)) {
-                return ResponseEntity.status(HttpStatus.FORBIDDEN)
-                    .body(
-                        ApiResponse.Error(
-                            code = 403,
-                            message = "You are not allowed to submit execution requests.",
-                            error =
-                                ApiError(
-                                    type = "EXECUTE_SUBMIT_NOT_ALLOWED",
-                                    details = "Submitter is not in whitelist.",
-                                ),
-                        )
-                    )
+            // After close time: only whitelist can submit; before close: no whitelist restriction
+            submissionPolicy.systemCloseAt?.toInstant()?.let { closeAt ->
+                val now = Instant.now()
+                val afterClose = !now.isBefore(closeAt)
+                if (afterClose) {
+                    val whitelist = submissionPolicy.executeSubmitWhitelist
+                    if (whitelist.isEmpty() || !whitelist.contains(currentUserId)) {
+                        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                            .body(
+                                ApiResponse.Error(
+                                    code = 403,
+                                    message = "System is closed; only whitelisted users may submit.",
+                                    error =
+                                        ApiError(
+                                            type = "SYSTEM_CLOSED",
+                                            details =
+                                                "Submitter is not in whitelist after close time.",
+                                        ),
+                                )
+                            )
+                    }
+                }
             }
             val firstSessionId = requests.firstOrNull()?.sessionId
 

--- a/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
+++ b/backend-controller/src/main/kotlin/org/rucca/snake/controller/domain/controller/ExecuteController.kt
@@ -88,7 +88,8 @@ class ExecuteController(
                             .body(
                                 ApiResponse.Error(
                                     code = 403,
-                                    message = "System is closed; only whitelisted users may submit.",
+                                    message =
+                                        "System is closed; only whitelisted users may submit.",
                                     error =
                                         ApiError(
                                             type = "SYSTEM_CLOSED",

--- a/backend-controller/src/main/resources/application.yml
+++ b/backend-controller/src/main/resources/application.yml
@@ -125,3 +125,14 @@ rate-limiter:
       refill-unit: SECONDS            # 补充单位: 秒
       key-expression: "'execution_freq:' + #userId" # Redis Key表达式
       tokens-expression: "1"        # 每次请求固定消耗1个令牌
+
+# ===============================================
+# Submission Policy
+# ===============================================
+submission-policy:
+  # 系统截止提交时间（ISO-8601，含时区）。到点后禁止提交编译/执行请求。
+  # 当前配置：2025-09-03 北京时间 13:00 关闭
+  system-close-at: "2025-09-03T13:00:00+08:00"
+  # 允许提交执行请求的用户ID白名单（按提交者校验；被执行的程序所有者不受限制）
+  # 为空表示不启用白名单限制
+  execute-submit-whitelist: []

--- a/docker-compose-deploy/docker-compose.local.yml
+++ b/docker-compose-deploy/docker-compose.local.yml
@@ -232,7 +232,7 @@ services:
     image: grafana/grafana-oss:12.0.4
     container_name: grafana
     ports:
-      - "3000:3000"
+      - "3002:3000"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana-provisioning/datasources:/etc/grafana/provisioning/datasources

--- a/docker-compose-deploy/docker-compose.yml
+++ b/docker-compose-deploy/docker-compose.yml
@@ -170,7 +170,7 @@ services:
       - '--web.console.libraries=/usr/share/prometheus/console_libraries'
       - '--web.console.templates=/usr/share/prometheus/consoles'
     ports:
-      - "9090:9090"
+      - "9091:9090"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:9090/-/ready > /dev/null"]
       start_period: 30s
@@ -186,7 +186,7 @@ services:
     image: grafana/grafana-oss:12.0.4
     container_name: grafana
     ports:
-      - "3000:3000"
+      - "3002:3000"
     volumes:
       - grafana_data:/var/lib/grafana
       - ./grafana-provisioning/datasources:/etc/grafana/provisioning/datasources


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - System-wide submission close: configurable cutoff that blocks submissions after a set time with a clear 403 response.
  - Submitter whitelist: optional whitelist permitting only listed users to submit after close time.

- Configuration
  - New settings to specify close time and execution-submit whitelist.

- Chores
  - Updated Docker Compose host ports: Prometheus on 9091; Grafana on 3002 (healthcheck URL may need update).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->